### PR TITLE
Around and After aspects should return result of function call.

### DIFF
--- a/lib/water_drop/aspects/after_aspect.rb
+++ b/lib/water_drop/aspects/after_aspect.rb
@@ -10,7 +10,6 @@ module WaterDrop
     #   )
     class AfterAspect < BaseAspect
       after options[:method], interception_arg: true do |interception, result, *args|
-        # puts result
         options = interception.options
         interception.aspect.handle(self, options, args, options[:message], result)
         result

--- a/lib/water_drop/aspects/after_aspect.rb
+++ b/lib/water_drop/aspects/after_aspect.rb
@@ -10,8 +10,10 @@ module WaterDrop
     #   )
     class AfterAspect < BaseAspect
       after options[:method], interception_arg: true do |interception, result, *args|
+        # puts result
         options = interception.options
         interception.aspect.handle(self, options, args, options[:message], result)
+        result
       end
     end
   end

--- a/lib/water_drop/aspects/around_aspect.rb
+++ b/lib/water_drop/aspects/around_aspect.rb
@@ -15,6 +15,7 @@ module WaterDrop
         interception.aspect.handle(self, options, args, options[:before_message])
         result = proxy.call(*args, &block)
         interception.aspect.handle(self, options, args, options[:after_message], result)
+        result
       end
     end
   end

--- a/spec/lib/water_drop/aspects/after_aspect_spec.rb
+++ b/spec/lib/water_drop/aspects/after_aspect_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe WaterDrop::Aspects::AfterAspect do
                                      topic: 'topic',
                                      message: message)
         expect(@instance).to receive(:puts).with('5')
-        @instance.run('arg')
+        expect(@instance.run('arg')).to eq(5)
       end
     end
 
@@ -62,7 +62,7 @@ RSpec.describe WaterDrop::Aspects::AfterAspect do
                                      topic: 'topic4',
                                      message: message_with_parameter)
         expect(message_with_parameter).to receive(:call).with(5780)
-        @instance.call('arg')
+        expect(@instance.call('arg')).to eq(5780)
       end
     end
   end

--- a/spec/lib/water_drop/aspects/around_aspect_spec.rb
+++ b/spec/lib/water_drop/aspects/around_aspect_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe WaterDrop::Aspects::AroundAspect do
       ClassBuilder.build do
         attr_accessor :instance_variable
         def run(*_args)
-          @instance_variable = 5
           puts 'method_call'
+          @instance_variable = 5
         end
 
         def run_another(*_args)
@@ -67,7 +67,7 @@ RSpec.describe WaterDrop::Aspects::AroundAspect do
                              )
 
         expect(@instance).to receive(:puts).with('5').ordered
-        @instance.run('arg')
+        expect(@instance.run('arg')).to eq(5)
       end
     end
 
@@ -90,7 +90,7 @@ RSpec.describe WaterDrop::Aspects::AroundAspect do
                                      after_message: message_with_parameter
                              )
         expect(message_with_parameter).to receive(:call).with(2390).ordered
-        @instance.run_another('arg')
+        expect(@instance.run_another('arg')).to eq(2390)
       end
     end
   end


### PR DESCRIPTION
WaterDrop::Aspects::AfterAspect.apply(
  Calculator,
  method: :sum,
  topic: 'karafka_topic_aspect',
  message: ->(result) { result }
)

class Calculator
  def sum(a, b)
    a + b
  end
end

Calculator.new.sum(4,5) # should return 9, now it returns true/false (whether message was sent)