### PR TITLE
Using asynchronous producer instead of synchronous

### DIFF
--- a/lib/water_drop/producer_proxy.rb
+++ b/lib/water_drop/producer_proxy.rb
@@ -54,7 +54,7 @@ module WaterDrop
     # @return [Kafka::Producer] producer instance to which we can forward method requests
     def producer
       reload! if dead?
-      @producer ||= Kafka.new(seed_brokers: ::WaterDrop.config.kafka.hosts).producer
+      @producer ||= Kafka.new(seed_brokers: ::WaterDrop.config.kafka.hosts).async_producer
     end
 
     # @return [Boolean] true if we cannot use producer anymore because it was not used for a

--- a/spec/lib/water_drop/producer_proxy_spec.rb
+++ b/spec/lib/water_drop/producer_proxy_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe WaterDrop::ProducerProxy do
         end
 
         it 'expect to reload and create producer' do
-          expect(kafka).to receive(:producer)
+          expect(kafka).to receive(:async_producer)
           subject.send :producer
         end
       end
@@ -150,7 +150,7 @@ RSpec.describe WaterDrop::ProducerProxy do
         end
 
         it 'expect not to reload and create producer' do
-          expect(kafka).to receive(:producer)
+          expect(kafka).to receive(:async_producer)
 
           subject.send :producer
         end


### PR DESCRIPTION
Using the synchronous producer is leading to some issues such as https://github.com/zendesk/ruby-kafka/issues/298. 

As the previous issue underlines, using the asynchronous producer should solve this kind of issue. https://github.com/zendesk/ruby-kafka#asynchronously-producing-messages 