### PR TITLE
Add topic prefix config support?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WaterDrop changelog
 
+## 0.3.3
+- Added `topic_prefix` config flag
+
 ## 0.3.2
 - Removed support for Ruby 2.1.*
 - ~~Ruby 2.3.3 as default~~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # WaterDrop changelog
 
-## 0.3.3
-- Added `topic_prefix` config flag
-
 ## 0.3.2
 - Removed support for Ruby 2.1.*
 - ~~Ruby 2.3.3 as default~~
@@ -11,6 +8,7 @@
 - Dry configurable config (#20)
 - added .rspec for default spec helper require
 - Added SSL capabilities
+- Added `topic_prefix` config flag
 
 ## 0.3.1
 - Dev tools update

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (0.3.2.3)
+    waterdrop (0.3.2.4)
       bundler
       connection_pool
       dry-configurable (~> 0.6)
@@ -167,4 +167,4 @@ DEPENDENCIES
   waterdrop!
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ WaterDrop has following configuration options:
 | kafka.ssl.ca_cert         | false      | String        | SSL CA certificate               |
 | kafka.ssl.client_cert     | false      | String        | SSL client certificate           |
 | kafka.ssl.client_cert_key | false      | String        | SSL client certificate password  |
-| kafka.topic_prefix        | false      | String        | Prefix to concatenate to topic   |
+| kafka.topic_mapper        | false      | Proc          | Proc that maps topic string (e.g prepending a topic prefix) |
 
 To apply this configuration, you need to use a *setup* method:
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ WaterDrop has following configuration options:
 | kafka.ssl.ca_cert         | false      | String        | SSL CA certificate               |
 | kafka.ssl.client_cert     | false      | String        | SSL client certificate           |
 | kafka.ssl.client_cert_key | false      | String        | SSL client certificate password  |
+| kafka.topic_prefix        | false      | String        | Prefix to concatenate to topic   |
 
 To apply this configuration, you need to use a *setup* method:
 

--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -17,8 +17,8 @@ module WaterDrop
     setting :kafka do
       # @option hosts [Array<String>] Array that contains Kafka hosts with ports
       setting :hosts
-      # Kafka topic prefix
-      setting :topic_prefix
+      # Kafka topic mapper [Proc [String->String]]
+      setting :topic_mapper
       # SSL authentication related settings
       setting :ssl do
         # option ca_cert [String] SSL CA certificate

--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -17,6 +17,8 @@ module WaterDrop
     setting :kafka do
       # @option hosts [Array<String>] Array that contains Kafka hosts with ports
       setting :hosts
+      # Kafka topic prefix
+      setting :topic_prefix
       # SSL authentication related settings
       setting :ssl do
         # option ca_cert [String] SSL CA certificate

--- a/lib/water_drop/message.rb
+++ b/lib/water_drop/message.rb
@@ -36,10 +36,10 @@ module WaterDrop
     end
 
     # Returns topic name
-    # @note Appends kafka.topic_prefix config flag if set
-    def topic
-      prefix = ::WaterDrop.config.kafka.topic_prefix
-      !prefix.nil? ? "#{prefix}#{@topic}" : @topic
+    # @note If kafka.topic_mapper is set, the topic will be set to the return
+    #       value of that block
+    def topic(mapper = WaterDrop.config.kafka.topic_mapper)
+      mapper.is_a?(Proc) ? mapper.call(@topic).to_s : @topic
     end
   end
 end

--- a/lib/water_drop/message.rb
+++ b/lib/water_drop/message.rb
@@ -39,7 +39,7 @@ module WaterDrop
     # @note Appends kafka.topic_prefix config flag if set
     def topic
       prefix = ::WaterDrop.config.kafka.topic_prefix
-      !!prefix ? "#{prefix}#{@topic}" : @topic
+      !prefix.nil? ? "#{prefix}#{@topic}" : @topic
     end
   end
 end

--- a/lib/water_drop/message.rb
+++ b/lib/water_drop/message.rb
@@ -1,7 +1,7 @@
 module WaterDrop
   # Message class which encapsulate single Kafka message logic and its delivery
   class Message
-    attr_reader :topic, :message, :options
+    attr_reader :message, :options
 
     # @param topic [String, Symbol] a topic to which we want to send a message
     # @param message [Object] any object that can be serialized to a JSON string or
@@ -33,6 +33,13 @@ module WaterDrop
       # Ignore if we dont want to know that something went wrong
       return unless ::WaterDrop.config.raise_on_failure
       raise(e)
+    end
+
+    # Returns topic name
+    # @note Appends kafka.topic_prefix config flag if set
+    def topic
+      prefix = ::WaterDrop.config.kafka.topic_prefix
+      !!prefix ? "#{prefix}#{@topic}" : @topic
     end
   end
 end

--- a/lib/water_drop/version.rb
+++ b/lib/water_drop/version.rb
@@ -2,5 +2,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '0.3.2.3'
+  VERSION = '0.3.2.4'
 end

--- a/spec/lib/water_drop/config_spec.rb
+++ b/spec/lib/water_drop/config_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe WaterDrop::Config do
   subject { described_class.config }
 
   %i(
-    connection_pool_timeout
-    send_messages
-    raise_on_failure
     connection_pool_size
+    connection_pool_timeout
+    raise_on_failure
+    send_messages
   ).each do |attribute|
     describe "#{attribute}=" do
       let(:value) { rand }

--- a/spec/lib/water_drop/message_spec.rb
+++ b/spec/lib/water_drop/message_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe WaterDrop::Message do
           .to receive_message_chain(:config, :send_messages)
           .and_return(true)
 
+        allow(WaterDrop)
+          .to receive_message_chain(:config, :kafka, :topic_prefix)
+          .and_return(nil)
+
         expect(WaterDrop::Pool).to receive(:with).and_yield(producer)
         expect(producer).to receive(:send_message)
           .with(any_args)
-      end
-
-      it 'sends message with topic and message' do
-        subject.send!
       end
     end
 
@@ -56,6 +56,30 @@ RSpec.describe WaterDrop::Message do
 
           it { expect { subject.send! }.to raise_error(error) }
         end
+      end
+    end
+  end
+
+  describe '#topic' do
+    let(:prefix) { nil }
+
+    before do
+      allow(WaterDrop)
+        .to receive_message_chain(:config, :kafka, :topic_prefix)
+        .and_return(prefix)
+    end
+
+    context 'with a topic prefix' do
+      let(:prefix) { 'cat' }
+      
+      it 'adds the prefix to the topic' do
+        expect(subject.topic).to eql("#{prefix}#{topic}")
+      end
+    end
+
+    context 'without a topic prefix' do
+      it 'does not change the topic' do
+        expect(subject.topic).to eql(topic.to_s)
       end
     end
   end

--- a/spec/lib/water_drop/message_spec.rb
+++ b/spec/lib/water_drop/message_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe WaterDrop::Message do
         expect(producer).to receive(:send_message)
           .with(any_args)
       end
+
+      it 'sends message with topic and message' do
+        subject.send!
+      end
     end
 
     [StandardError].each do |error|
@@ -71,7 +75,7 @@ RSpec.describe WaterDrop::Message do
 
     context 'with a topic prefix' do
       let(:prefix) { 'cat' }
-      
+
       it 'adds the prefix to the topic' do
         expect(subject.topic).to eql("#{prefix}#{topic}")
       end


### PR DESCRIPTION
Some Kafka providers, like the one in this screenshot, assign topic prefixes to their lower/free tier products. I thought this might be useful because it seems to be a common practice among some providers.

![image](https://cloud.githubusercontent.com/assets/396039/25310873/12feb6f0-27be-11e7-9071-abf0d9138a86.png)


I added a `topic_prefix` option to the config, and implemented `#topic` to check for the option and interpolate in the prefix if set, and wrote a test. I can work off of my fork if you don't wish to merge this, but I suppose it might be useful to others as well. :unicorn: 