### PR TITLE
Support using AsyncProducer

### DIFF
--- a/lib/water_drop.rb
+++ b/lib/water_drop.rb
@@ -29,7 +29,7 @@ base_path = File.dirname(__FILE__) + '/water_drop'
 # WaterDrop library
 module WaterDrop
   class << self
-    attr_writer :logger
+    attr_accessor :logger
 
     # @return [Logger] logger that we want to use
     def logger

--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -28,6 +28,21 @@ module WaterDrop
         # option client_cert_key [String] SSL client certificate password
         setting :client_cert_key, nil
       end
+      # Kafka Producer related settings
+      setting :producer do
+        # @option delivery_threshold [] TODO (Only applies when using async_producer)
+        setting :delivery_threshold
+        # @option delivery_interval [] TODO (Only applies when using async_producer)
+        setting :delivery_interval
+        # @option max_buffer_size [] TODO (Only applies when using async_producer)
+        setting :max_buffer_size, 0
+        # @option max_buffer_bytesize [] TODO
+        setting :max_buffer_bytesize, 0
+        # @option max_queue_size
+        setting :max_queue_size, 1000
+        # @option use_async_producer [] TODO
+        setting :use_async_producer, false
+      end
     end
 
     class << self

--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -31,9 +31,9 @@ module WaterDrop
       # Kafka Producer related settings
       setting :producer do
         # @option delivery_threshold [] TODO (Only applies when using async_producer)
-        setting :delivery_threshold
+        setting :delivery_threshold, 0
         # @option delivery_interval [] TODO (Only applies when using async_producer)
-        setting :delivery_interval
+        setting :delivery_interval, 0
         # @option max_buffer_size [] TODO (Only applies when using async_producer)
         setting :max_buffer_size, 0
         # @option max_buffer_bytesize [] TODO

--- a/lib/water_drop/producer_proxy.rb
+++ b/lib/water_drop/producer_proxy.rb
@@ -65,21 +65,15 @@ module WaterDrop
       )
 
       if ::WaterDrop.config.kafka.producer.use_async_producer
-        @producer ||= kafka.async_producer(
-          sync_producer: kafka.producer(
-            max_buffer_size: ::WaterDrop.config.kafka.producer.max_buffer_size,
-            max_buffer_bytesize: ::WaterDrop.config.kafka.producer.max_buffer_bytesize
-          ),
+        @producer ||= @kafka.async_producer(
+          sync_producer: create_sync_producer,
           max_queue_size: ::WaterDrop.config.kafka.producer.max_queue_size,
           delivery_threshold: ::WaterDrop.config.kafka.producer.delivery_threshold,
           delivery_interval: ::WaterDrop.config.kafka.producer.delivery_threshold,
           logger: ::WaterDrop.logger
         )
       else
-        @producer ||= kafka.producer(
-          max_buffer_size: ::WaterDrop.config.kafka.producer.max_buffer_size,
-          max_buffer_bytesize: ::WaterDrop.config.kafka.producer.max_buffer_bytesize
-        )
+        @producer ||= create_sync_producer
       end
     end
 
@@ -94,5 +88,14 @@ module WaterDrop
       @producer&.shutdown
       @producer = nil
     end
+
+  private
+    def create_sync_producer
+      @kafka.producer(
+        max_buffer_size: ::WaterDrop.config.kafka.producer.max_buffer_size,
+        max_buffer_bytesize: ::WaterDrop.config.kafka.producer.max_buffer_bytesize
+      )
+    end
+
   end
 end

--- a/lib/water_drop/producer_proxy.rb
+++ b/lib/water_drop/producer_proxy.rb
@@ -67,14 +67,9 @@ module WaterDrop
 
       if ::WaterDrop.config.kafka.producer.use_async_producer
         @producer ||= @kafka.async_producer(
-          # sync_producer: @kafka.producer(
-          #   max_buffer_size: ::WaterDrop.config.kafka.producer.max_buffer_size,
-          #   max_buffer_bytesize: ::WaterDrop.config.kafka.producer.max_buffer_bytesize
-          # ),
           max_queue_size: ::WaterDrop.config.kafka.producer.max_queue_size,
           delivery_threshold: ::WaterDrop.config.kafka.producer.delivery_threshold,
           delivery_interval: ::WaterDrop.config.kafka.producer.delivery_interval,
-          #logger: ::WaterDrop.logger
         )
       else
         @producer ||= @kafka.producer(

--- a/lib/water_drop/producer_proxy.rb
+++ b/lib/water_drop/producer_proxy.rb
@@ -47,6 +47,11 @@ module WaterDrop
       @attempts = 0
     end
 
+    def shutdown
+      @producer.shutdown if @producer
+      @producer = nil
+    end
+
     private
 
     # Refreshes last usage value with current time

--- a/lib/water_drop/producer_proxy.rb
+++ b/lib/water_drop/producer_proxy.rb
@@ -67,14 +67,14 @@ module WaterDrop
 
       if ::WaterDrop.config.kafka.producer.use_async_producer
         @producer ||= @kafka.async_producer(
-          sync_producer: @kafka.producer(
-            max_buffer_size: ::WaterDrop.config.kafka.producer.max_buffer_size,
-            max_buffer_bytesize: ::WaterDrop.config.kafka.producer.max_buffer_bytesize
-          ),
+          # sync_producer: @kafka.producer(
+          #   max_buffer_size: ::WaterDrop.config.kafka.producer.max_buffer_size,
+          #   max_buffer_bytesize: ::WaterDrop.config.kafka.producer.max_buffer_bytesize
+          # ),
           max_queue_size: ::WaterDrop.config.kafka.producer.max_queue_size,
           delivery_threshold: ::WaterDrop.config.kafka.producer.delivery_threshold,
           delivery_interval: ::WaterDrop.config.kafka.producer.delivery_threshold,
-          logger: ::WaterDrop.logger
+          #logger: ::WaterDrop.logger
         )
       else
         @producer ||= @kafka.producer(

--- a/lib/water_drop/producer_proxy.rb
+++ b/lib/water_drop/producer_proxy.rb
@@ -73,7 +73,7 @@ module WaterDrop
           # ),
           max_queue_size: ::WaterDrop.config.kafka.producer.max_queue_size,
           delivery_threshold: ::WaterDrop.config.kafka.producer.delivery_threshold,
-          delivery_interval: ::WaterDrop.config.kafka.producer.delivery_threshold,
+          delivery_interval: ::WaterDrop.config.kafka.producer.delivery_interval,
           #logger: ::WaterDrop.logger
         )
       else

--- a/lib/water_drop/producer_proxy.rb
+++ b/lib/water_drop/producer_proxy.rb
@@ -22,6 +22,7 @@ module WaterDrop
     def initialize
       touch
       @attempts = 0
+      @is_sync = !::WaterDrop.config.kafka.producer.use_async_producer
     end
 
     # Sends message to Kafka
@@ -35,7 +36,7 @@ module WaterDrop
       producer.produce(message.message, {
         topic: message.topic
       }.merge(message.options))
-      producer.deliver_messages
+      producer.deliver_messages if @is_sync
     rescue StandardError => e
       reload!
 

--- a/lib/water_drop/producer_proxy.rb
+++ b/lib/water_drop/producer_proxy.rb
@@ -67,14 +67,20 @@ module WaterDrop
 
       if ::WaterDrop.config.kafka.producer.use_async_producer
         @producer ||= @kafka.async_producer(
-          sync_producer: self.create_sync_producer,
+          sync_producer: @kafka.producer(
+            max_buffer_size: ::WaterDrop.config.kafka.producer.max_buffer_size,
+            max_buffer_bytesize: ::WaterDrop.config.kafka.producer.max_buffer_bytesize
+          ),
           max_queue_size: ::WaterDrop.config.kafka.producer.max_queue_size,
           delivery_threshold: ::WaterDrop.config.kafka.producer.delivery_threshold,
           delivery_interval: ::WaterDrop.config.kafka.producer.delivery_threshold,
           logger: ::WaterDrop.logger
         )
       else
-        @producer ||= self.create_sync_producer
+        @producer ||= @kafka.producer(
+          max_buffer_size: ::WaterDrop.config.kafka.producer.max_buffer_size,
+          max_buffer_bytesize: ::WaterDrop.config.kafka.producer.max_buffer_bytesize
+        )
       end
     end
 
@@ -89,15 +95,5 @@ module WaterDrop
       @producer&.shutdown
       @producer = nil
     end
-
-  private
-    def create_sync_producer
-      sync_producer = @kafka.producer(
-        max_buffer_size: ::WaterDrop.config.kafka.producer.max_buffer_size,
-        max_buffer_bytesize: ::WaterDrop.config.kafka.producer.max_buffer_bytesize
-      )
-      sync_producer
-    end
-
   end
 end

--- a/lib/water_drop/producer_proxy.rb
+++ b/lib/water_drop/producer_proxy.rb
@@ -67,14 +67,14 @@ module WaterDrop
 
       if ::WaterDrop.config.kafka.producer.use_async_producer
         @producer ||= @kafka.async_producer(
-          sync_producer: create_sync_producer,
+          sync_producer: self.create_sync_producer,
           max_queue_size: ::WaterDrop.config.kafka.producer.max_queue_size,
           delivery_threshold: ::WaterDrop.config.kafka.producer.delivery_threshold,
           delivery_interval: ::WaterDrop.config.kafka.producer.delivery_threshold,
           logger: ::WaterDrop.logger
         )
       else
-        @producer ||= create_sync_producer
+        @producer ||= self.create_sync_producer
       end
     end
 
@@ -92,10 +92,11 @@ module WaterDrop
 
   private
     def create_sync_producer
-      @kafka.producer(
+      sync_producer = @kafka.producer(
         max_buffer_size: ::WaterDrop.config.kafka.producer.max_buffer_size,
         max_buffer_bytesize: ::WaterDrop.config.kafka.producer.max_buffer_bytesize
       )
+      sync_producer
     end
 
   end

--- a/spec/lib/water_drop/producer_proxy_spec.rb
+++ b/spec/lib/water_drop/producer_proxy_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe WaterDrop::ProducerProxy do
         expect(Kafka)
           .to receive(:new)
           .with(
+            logger: ::WaterDrop.logger,
             seed_brokers: ::WaterDrop.config.kafka.hosts,
             ssl_ca_cert: ::WaterDrop.config.kafka.ssl.ca_cert,
             ssl_client_cert: ::WaterDrop.config.kafka.ssl.client_cert,
@@ -139,6 +140,7 @@ RSpec.describe WaterDrop::ProducerProxy do
         expect(Kafka)
           .to receive(:new)
           .with(
+            logger: ::WaterDrop.logger,
             seed_brokers: ::WaterDrop.config.kafka.hosts,
             ssl_ca_cert: ::WaterDrop.config.kafka.ssl.ca_cert,
             ssl_client_cert: ::WaterDrop.config.kafka.ssl.client_cert,


### PR DESCRIPTION
• Added config options for both AsyncProducer (auto delivery options) and Producer (buffer size options)
• Use 'logger' from WaterDrop::logger to get errors logged when occurring in AsyncProducer
• Updated tests
