### PR TITLE
support ruby-kafka 0.4.0 `ssl_ca_cert_file_path` option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       dry-configurable (~> 0.6)
       null-logger
       rake
-      ruby-kafka
+      ruby-kafka (~> 0.4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -54,4 +54,4 @@ DEPENDENCIES
   waterdrop!
 
 BUNDLED WITH
-   1.13.7
+   1.15.0

--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -23,6 +23,8 @@ module WaterDrop
       setting :ssl do
         # option ca_cert [String] SSL CA certificate
         setting :ca_cert, nil
+        # option ssl_ca_cert_file_path [String] SSL CA certificate
+        setting :ca_cert_file_path, nil
         # option client_cert [String] SSL client certificate
         setting :client_cert, nil
         # option client_cert_key [String] SSL client certificate password

--- a/lib/water_drop/producer_proxy.rb
+++ b/lib/water_drop/producer_proxy.rb
@@ -60,7 +60,8 @@ module WaterDrop
         seed_brokers: ::WaterDrop.config.kafka.hosts,
         ssl_ca_cert: ::WaterDrop.config.kafka.ssl.ca_cert,
         ssl_client_cert: ::WaterDrop.config.kafka.ssl.client_cert,
-        ssl_client_cert_key: ::WaterDrop.config.kafka.ssl.client_cert_key
+        ssl_client_cert_key: ::WaterDrop.config.kafka.ssl.client_cert_key,
+        ssl_ca_cert_file_path: ::WaterDrop.config.kafka.ssl.ca_cert_file_path
       ).producer
     end
 

--- a/spec/lib/water_drop/config_spec.rb
+++ b/spec/lib/water_drop/config_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe WaterDrop::Config do
 
   %i[
     ca_cert
+    ca_cert_file_path
     client_cert
     client_cert_key
   ].each do |attribute|

--- a/spec/lib/water_drop/producer_proxy_spec.rb
+++ b/spec/lib/water_drop/producer_proxy_spec.rb
@@ -119,7 +119,8 @@ RSpec.describe WaterDrop::ProducerProxy do
             seed_brokers: ::WaterDrop.config.kafka.hosts,
             ssl_ca_cert: ::WaterDrop.config.kafka.ssl.ca_cert,
             ssl_client_cert: ::WaterDrop.config.kafka.ssl.client_cert,
-            ssl_client_cert_key: ::WaterDrop.config.kafka.ssl.client_cert_key
+            ssl_client_cert_key: ::WaterDrop.config.kafka.ssl.client_cert_key,
+            ssl_ca_cert_file_path: ::WaterDrop.config.kafka.ssl.ca_cert_file_path
           ).and_return(kafka)
       end
 
@@ -142,7 +143,8 @@ RSpec.describe WaterDrop::ProducerProxy do
             seed_brokers: ::WaterDrop.config.kafka.hosts,
             ssl_ca_cert: ::WaterDrop.config.kafka.ssl.ca_cert,
             ssl_client_cert: ::WaterDrop.config.kafka.ssl.client_cert,
-            ssl_client_cert_key: ::WaterDrop.config.kafka.ssl.client_cert_key
+            ssl_client_cert_key: ::WaterDrop.config.kafka.ssl.client_cert_key,
+            ssl_ca_cert_file_path: ::WaterDrop.config.kafka.ssl.ca_cert_file_path
           )
           .and_return(kafka)
       end

--- a/waterdrop.gemspec
+++ b/waterdrop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bundler', '>= 0'
   spec.add_dependency 'rake', '>= 0'
-  spec.add_dependency 'ruby-kafka', '>= 0'
+  spec.add_dependency 'ruby-kafka', '~> 0.4.0'
   spec.add_dependency 'connection_pool', '>= 0'
   spec.add_dependency 'null-logger'
   spec.add_dependency 'dry-configurable', '~> 0.6'


### PR DESCRIPTION
Required to support Heroku Kafka ca cert rotation. See: https://devcenter.heroku.com/changelog-items/1197