### PR TITLE
added producer compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,27 @@ bundle install
 
 WaterDrop has following configuration options:
 
-| Option                      | Required   | Value type      | Description                                                                        |
-|-----------------------------|------------|-----------------|------------------------------------------------------------------------------------|
-| send_messages               | true       | Boolean         | Should we send messages to Kafka                                                   |
-| connect_timeout             | false      | Integer         | Number of seconds to wait while connecting to a broker for the first time          |
-| required_acks               | false      | Symbol, Integer | [:all, 0, 1] acknowledgement level for Kafka                                       |
-| socket_timeout              | false      | Integer         | Number of seconds to wait when reading from or writing to a socket                 |
-| connection_pool.size        | true       | Integer         | Kafka connection pool size                                                         |
-| connection_pool.timeout     | true       | Integer         | Kafka connection pool timeout                                                      |
-| kafka.seed_brokers          | true       | Array<String>   | Kafka servers hosts with ports                                                     |
-| raise_on_failure            | true       | Boolean         | Should we raise an exception when we cannot send message to Kafka - if false will silently ignore failures |
-| kafka.ssl_ca_cert           | false      | String          | SSL CA certificate                                                                 |
-| kafka.ssl_ca_cert_file_path | false      | String          | SSL CA certificate file path                                                       |
-| kafka.ssl_client_cert       | false      | String          | SSL client certificate                                                             |
-| kafka.ssl_client_cert_key   | false      | String          | SSL client certificate password                                                    |
-| kafka.sasl_gssapi_principal | false      | String          | SASL principal                                                                     |
-| kafka.sasl_gssapi_keytab    | false      | String          | SASL keytab                                                                        |
-| kafka.sasl_plain_authzid    | false      | String          | The authorization identity to use                                                  |
-| kafka.sasl_plain_username   | false      | String          | The username used to authenticate                                                  |
-| kafka.sasl_plain_password   | false      | String          | The password used to authenticate                                                  |
+| Option                         | Required   | Value type      | Description                                                                        |
+|--------------------------------|------------|-----------------|------------------------------------------------------------------------------------|
+| send_messages                  | true       | Boolean         | Should we send messages to Kafka                                                   |
+| connect_timeout                | false      | Integer         | Number of seconds to wait while connecting to a broker for the first time          |
+| required_acks                  | false      | Symbol, Integer | [:all, 0, 1] acknowledgement level for Kafka                                       |
+| socket_timeout                 | false      | Integer         | Number of seconds to wait when reading from or writing to a socket                 |
+| connection_pool.size           | true       | Integer         | Kafka connection pool size                                                         |
+| connection_pool.timeout        | true       | Integer         | Kafka connection pool timeout                                                      |
+| kafka.seed_brokers             | true       | Array<String>   | Kafka servers hosts with ports                                                     |
+| raise_on_failure               | true       | Boolean         | Should we raise an exception when we cannot send message to Kafka - if false will silently ignore failures |
+| kafka.ssl_ca_cert              | false      | String          | SSL CA certificate                                                                 |
+| kafka.ssl_ca_cert_file_path    | false      | String          | SSL CA certificate file path                                                       |
+| kafka.ssl_client_cert          | false      | String          | SSL client certificate                                                             |
+| kafka.ssl_client_cert_key      | false      | String          | SSL client certificate password                                                    |
+| kafka.sasl_gssapi_principal    | false      | String          | SASL principal                                                                     |
+| kafka.sasl_gssapi_keytab       | false      | String          | SASL keytab                                                                        |
+| kafka.sasl_plain_authzid       | false      | String          | The authorization identity to use                                                  |
+| kafka.sasl_plain_username      | false      | String          | The username used to authenticate                                                  |
+| kafka.sasl_plain_password      | false      | String          | The password used to authenticate                                                  |
+| producer.compression_codec     | false      | Symbol          | Producer compression codec                                                         |
+| producer.compression_threshold | false      | Integer         | Producer compression threshold                                                     |
 
 To apply this configuration, you need to use a *setup* method:
 

--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -62,6 +62,17 @@ module WaterDrop
       setting :sasl_plain_password, nil
     end
 
+    # option producer [Hash] - optional - producer configuration options
+    setting :producer do
+      # option compression_codec [Symbol] Sets producer compression codec
+      # More: https://github.com/zendesk/ruby-kafka#compression
+      # More: https://github.com/zendesk/ruby-kafka/blob/master/lib/kafka/compression.rb
+      setting :compression_codec, nil
+      # option compression_codec [Integer] Sets producerc compression threshold
+      # More: https://github.com/zendesk/ruby-kafka#compression
+      setting :compression_threshold, 1
+    end
+
     class << self
       # Configurating method
       # @yield Runs a block of code providing a config singleton instance to it

--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -68,7 +68,7 @@ module WaterDrop
       # More: https://github.com/zendesk/ruby-kafka#compression
       # More: https://github.com/zendesk/ruby-kafka/blob/master/lib/kafka/compression.rb
       setting :compression_codec, nil
-      # option compression_codec [Integer] Sets producerc compression threshold
+      # option compression_codec [Integer] Sets producer compression threshold
       # More: https://github.com/zendesk/ruby-kafka#compression
       setting :compression_threshold, 1
     end

--- a/lib/water_drop/producer_proxy.rb
+++ b/lib/water_drop/producer_proxy.rb
@@ -63,6 +63,8 @@ module WaterDrop
           logger: ::WaterDrop.config.logger
         }.merge(::WaterDrop.config.kafka.to_h)
       ).producer(
+        compression_codec: ::WaterDrop.config.producer.compression_codec,
+        compression_threshold: ::WaterDrop.config.producer.compression_threshold,
         required_acks: ::WaterDrop.config.required_acks
       )
     end

--- a/spec/lib/water_drop/config_spec.rb
+++ b/spec/lib/water_drop/config_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe WaterDrop::Config do
     end
   end
 
+  %i[
+    compression_codec
+    compression_threshold
+  ].each do |attribute|
+    describe "producer.#{attribute}=" do
+      let(:value) { rand }
+
+      before { config.producer[attribute] = value }
+
+      it 'assigns a given value' do
+        expect(config.producer[attribute]).to eq value
+      end
+    end
+  end
+
   describe 'kafka.seed_brokers=' do
     let(:value) { rand }
 

--- a/spec/lib/water_drop/producer_proxy_spec.rb
+++ b/spec/lib/water_drop/producer_proxy_spec.rb
@@ -113,6 +113,13 @@ RSpec.describe WaterDrop::ProducerProxy do
         logger: ::WaterDrop.config.logger
       }.merge(::WaterDrop.config.kafka.to_h)
     end
+    let(:producer_init_parameters) do
+      {
+        compression_codec: ::WaterDrop.config.producer.compression_codec,
+        compression_threshold: ::WaterDrop.config.producer.compression_threshold,
+        required_acks: ::WaterDrop.config.required_acks
+      }
+    end
 
     before do
       WaterDrop.config.kafka.seed_brokers = kafka
@@ -134,7 +141,7 @@ RSpec.describe WaterDrop::ProducerProxy do
       end
 
       it 'expect to reload and create producer' do
-        expect(kafka).to receive(:producer)
+        expect(kafka).to receive(:producer).with(producer_init_parameters)
         producer_proxy.send :producer
       end
     end


### PR DESCRIPTION
We'd like to leverage `ruby-kafka`'s built in compression. This change will not introduce any backward incompatibility since it sets defaults to not enabling compression.