### PR TITLE
api sync, typos fixes and null-logger removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ app.god
 
 # minimal Rails specific artifacts
 db/*.sqlite3
-/log/*
+/log/*.log
 /tmp/*
 *.gem
 *.~

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'null-logger', path: '../null-logger'
-
 group :test do
   gem 'rspec'
   gem 'simplecov'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'null-logger', path: '../null-logger'
+
 group :test do
   gem 'rspec'
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,4 @@
 PATH
-  remote: ../null-logger
-  specs:
-    null-logger (0.1.6)
-
-PATH
   remote: .
   specs:
     waterdrop (1.3.0)
@@ -87,7 +82,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  null-logger!
   rspec
   simplecov
   waterdrop!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,9 @@
 PATH
+  remote: ../null-logger
+  specs:
+    null-logger (0.1.6)
+
+PATH
   remote: .
   specs:
     waterdrop (1.3.0)
@@ -6,13 +11,12 @@ PATH
       dry-configurable (~> 0.8)
       dry-monitor (~> 0.3)
       dry-validation (~> 0.11)
-      null-logger (~> 0.1)
       ruby-kafka (>= 0.7.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     delivery_boy (0.2.7)
       king_konf (~> 0.2)
       ruby-kafka (~> 0.5)
@@ -58,7 +62,6 @@ GEM
       dry-types (~> 0.14, >= 0.14)
     json (2.2.0)
     king_konf (0.3.7)
-    null-logger (0.1.5)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -72,7 +75,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    ruby-kafka (0.7.5)
+    ruby-kafka (0.7.6)
       digest-crc
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -84,6 +87,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  null-logger!
   rspec
   simplecov
   waterdrop!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       dry-configurable (~> 0.1, >= 0.1.3)
     dry-core (0.4.7)
       concurrent-ruby (~> 1.0)
-    dry-equalizer (0.2.1)
+    dry-equalizer (0.2.2)
     dry-events (0.1.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4)

--- a/config/errors.yml
+++ b/config/errors.yml
@@ -14,3 +14,5 @@ en:
       Both ssl_client_cert_chain and ssl_client_cert_key need to be provided.
     ssl_client_cert_key_password_with_ssl_client_cert_key: >
       Both ssl_client_cert_key_password and ssl_client_cert_key need to be provided.
+    sasl_oauth_token_provider_respond_to_token: >
+      sasl_oauth_token_provider needs to respond to a #token method.

--- a/lib/water_drop.rb
+++ b/lib/water_drop.rb
@@ -4,7 +4,6 @@
 %w[
   json
   delivery_boy
-  null_logger
   singleton
   dry-configurable
   dry/monitor/notifications

--- a/lib/water_drop/base_producer.rb
+++ b/lib/water_drop/base_producer.rb
@@ -19,12 +19,12 @@ module WaterDrop
       end
 
       # Upon failed delivery, we may try to resend a message depending on the attempt number
-      #   or reraise an error if we're unable to do that after given number of retries
+      #   or re-raise an error if we're unable to do that after given number of retries
       #   This method checks that and also instruments errors and retries for the delivery
       # @param attempts_count [Integer] number of attempt (starting from 1) for the delivery
       # @param message [String] message that we want to send to Kafka
       # @param options [Hash] options (including topic) for producer
-      # @param error [Kafka::Error] error that occured
+      # @param error [Kafka::Error] error that occurred
       # @return [Boolean] true if this is a graceful attempt and we can retry or false it this
       #   was the final one and we should deal with the fact, that we cannot deliver a given
       #   message

--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -11,7 +11,7 @@ module WaterDrop
     # option client_id [String] identifier of this producer
     setting :client_id, 'waterdrop'
     # option [Instance, nil] logger that we want to use or nil to fallback to ruby-kafka logger
-    setting :logger, Logger.new($stdout)
+    setting :logger, Logger.new($stdout).tap { |logger| logger.level = Logger::WARN }
     # option [Instance] monitor that we want to use. See instrumentation part of the README for
     #   more details
     setting :monitor, WaterDrop::Instrumentation::Monitor.instance

--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -11,7 +11,7 @@ module WaterDrop
     # option client_id [String] identifier of this producer
     setting :client_id, 'waterdrop'
     # option [Instance, nil] logger that we want to use or nil to fallback to ruby-kafka logger
-    setting :logger, NullLogger.new
+    setting :logger, Logger.new($stdout)
     # option [Instance] monitor that we want to use. See instrumentation part of the README for
     #   more details
     setting :monitor, WaterDrop::Instrumentation::Monitor.instance

--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -3,7 +3,7 @@
 # Configuration and descriptions are based on the delivery boy zendesk gem
 # @see https://github.com/zendesk/delivery_boy
 module WaterDrop
-  # Configurator for setting up all options required by WaterDrop
+  # Configuration object for setting up all options required by WaterDrop
   class Config
     extend Dry::Configurable
 
@@ -115,10 +115,13 @@ module WaterDrop
       # option ssl_client_cert_key_password [String, nil] the password required to read
       #   the ssl_client_cert_key
       setting :ssl_client_cert_key_password, nil
+      # @param sasl_oauth_token_provider [Object, nil] OAuthBearer Token Provider instance that
+      #   implements method token.
+      setting :sasl_oauth_token_provider, nil
     end
 
     class << self
-      # Configurating method
+      # Configuration method
       # @yield Runs a block of code providing a config singleton instance to it
       # @yieldparam [WaterDrop::Config] WaterDrop config instance
       def setup

--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -11,7 +11,7 @@ module WaterDrop
     # option client_id [String] identifier of this producer
     setting :client_id, 'waterdrop'
     # option [Instance, nil] logger that we want to use or nil to fallback to ruby-kafka logger
-    setting :logger, Logger.new($stdout).tap { |logger| logger.level = Logger::WARN }
+    setting :logger, Logger.new($stdout, level: Logger::WARN)
     # option [Instance] monitor that we want to use. See instrumentation part of the README for
     #   more details
     setting :monitor, WaterDrop::Instrumentation::Monitor.instance

--- a/lib/water_drop/config_applier.rb
+++ b/lib/water_drop/config_applier.rb
@@ -29,7 +29,7 @@ module WaterDrop
       # that are ported 1:1 from ruby-kafka
       # For some crazy reason, delivery boy requires compression codec as a string, when
       # ruby-kafka as a symbol. We follow ruby-kafka internal design, so we had to mimic
-      # that by assigning a stringified version that down the road will be symbolized again
+      # that by assigning a string version that down the road will be symbolized again
       # by delivery boy
       # @param delivery_boy_config [DeliveryBoy::Config] delivery boy config instance
       # @param codec_name [Symbol] codec name as a symbol

--- a/lib/water_drop/errors.rb
+++ b/lib/water_drop/errors.rb
@@ -9,7 +9,7 @@ module WaterDrop
     # Raised when configuration doesn't match with validation schema
     InvalidConfiguration = Class.new(BaseError)
 
-    # Raised when we try to send message with invalid optionss
+    # Raised when we try to send message with invalid options
     InvalidMessageOptions = Class.new(BaseError)
 
     # Raised when want to hook up to an event that is not registered and supported

--- a/lib/water_drop/instrumentation/monitor.rb
+++ b/lib/water_drop/instrumentation/monitor.rb
@@ -5,7 +5,7 @@ module WaterDrop
   module Instrumentation
     # Monitor is used to hookup external monitoring services to monitor how WaterDrop works
     # Since it is a pub-sub based on dry-monitor, you can use as many subscribers/loggers at the
-    # same time, which means that you might have for example file logging and newrelic at the same
+    # same time, which means that you might have for example file logging and NewRelic at the same
     # time
     # @note This class acts as a singleton because we are only permitted to have single monitor
     #   per running process (just as logger)

--- a/lib/water_drop/schemas/config.rb
+++ b/lib/water_drop/schemas/config.rb
@@ -65,6 +65,7 @@ module WaterDrop
           sasl_plain_password
           sasl_scram_username
           sasl_scram_password
+          sasl_oauth_token_provider
         ].each do |encryption_attribute|
           optional(encryption_attribute).maybe(:str?)
         end

--- a/lib/water_drop/schemas/config.rb
+++ b/lib/water_drop/schemas/config.rb
@@ -65,13 +65,13 @@ module WaterDrop
           sasl_plain_password
           sasl_scram_username
           sasl_scram_password
-          sasl_oauth_token_provider
         ].each do |encryption_attribute|
           optional(encryption_attribute).maybe(:str?)
         end
 
         optional(:ssl_ca_certs_from_system).maybe(:bool?)
         optional(:sasl_over_ssl).maybe(:bool?)
+        optional(:sasl_oauth_token_provider)
 
         # It's not with other encryptions as it has some more rules
         optional(:sasl_scram_mechanism)

--- a/lib/water_drop/schemas/config.rb
+++ b/lib/water_drop/schemas/config.rb
@@ -25,6 +25,12 @@ module WaterDrop
         rescue URI::InvalidURIError
           false
         end
+
+        # @param object [Object] an object that is suppose to respond to #token method
+        # @return [Boolean] true if an object responds to #token method
+        def respond_to_token?(object)
+          object.respond_to?(:token)
+        end
       end
 
       required(:client_id).filled(:str?, format?: Schemas::TOPIC_REGEXP)
@@ -71,7 +77,7 @@ module WaterDrop
 
         optional(:ssl_ca_certs_from_system).maybe(:bool?)
         optional(:sasl_over_ssl).maybe(:bool?)
-        optional(:sasl_oauth_token_provider)
+        optional(:sasl_oauth_token_provider).maybe
 
         # It's not with other encryptions as it has some more rules
         optional(:sasl_scram_mechanism)
@@ -111,6 +117,14 @@ module WaterDrop
           ]
         ) do |ssl_client_cert_key_password, ssl_client_cert_key|
           ssl_client_cert_key_password.filled? > ssl_client_cert_key.filled?
+        end
+
+        rule(
+          sasl_oauth_token_provider_respond_to_token: %i[
+            sasl_oauth_token_provider
+          ]
+        ) do |sasl_oauth_token_provider|
+          sasl_oauth_token_provider.filled? > sasl_oauth_token_provider.respond_to_token?
         end
       end
     end

--- a/lib/water_drop/schemas/message_options.rb
+++ b/lib/water_drop/schemas/message_options.rb
@@ -2,7 +2,7 @@
 
 module WaterDrop
   module Schemas
-    # Regexp to check that topic has a valid format
+    # Regex to check that topic has a valid format
     TOPIC_REGEXP = /\A(\w|\-|\.)+\z/.freeze
 
     # Schema with validation rules for validating that all the message options that

--- a/spec/lib/water_drop/schemas/config_spec.rb
+++ b/spec/lib/water_drop/schemas/config_spec.rb
@@ -934,4 +934,12 @@ RSpec.describe WaterDrop::Schemas::Config do
       it { expect(schema.call(config)).not_to be_success }
     end
   end
+
+  context 'when we validate sasl_oauth_token_provider' do
+    context 'when sasl_oauth_token_provider is nil' do
+      before { config[:kafka][:sasl_oauth_token_provider] = nil }
+
+      it { expect(schema.call(config)).to be_success }
+    end
+  end
 end

--- a/spec/lib/water_drop/schemas/config_spec.rb
+++ b/spec/lib/water_drop/schemas/config_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe WaterDrop::Schemas::Config do
   let(:config) do
     {
       client_id: 'id',
-      logger: NullLogger.new,
+      logger: Logger.new('/dev/null'),
       deliver: false,
       raise_on_buffer_overflow: true,
       kafka: {

--- a/spec/lib/water_drop/schemas/config_spec.rb
+++ b/spec/lib/water_drop/schemas/config_spec.rb
@@ -942,8 +942,15 @@ RSpec.describe WaterDrop::Schemas::Config do
       it { expect(schema.call(config)).to be_success }
     end
 
-    context 'when sasl_oauth_token_provider is an object' do
+    context 'when sasl_oauth_token_provider is an object without token method' do
       before { config[:kafka][:sasl_oauth_token_provider] = Struct.new(:test).new }
+
+      it { expect(schema.call(config)).to be_failure }
+      it { expect { schema.call(config).errors }.not_to raise_error }
+    end
+
+    context 'when sasl_oauth_token_provider is an object with token method' do
+      before { config[:kafka][:sasl_oauth_token_provider] = Struct.new(:token).new }
 
       it { expect(schema.call(config)).to be_success }
     end

--- a/spec/lib/water_drop/schemas/config_spec.rb
+++ b/spec/lib/water_drop/schemas/config_spec.rb
@@ -941,5 +941,11 @@ RSpec.describe WaterDrop::Schemas::Config do
 
       it { expect(schema.call(config)).to be_success }
     end
+
+    context 'when sasl_oauth_token_provider is an object' do
+      before { config[:kafka][:sasl_oauth_token_provider] = Struct.new(:test).new }
+
+      it { expect(schema.call(config)).to be_success }
+    end
   end
 end

--- a/spec/lib/water_drop_spec.rb
+++ b/spec/lib/water_drop_spec.rb
@@ -7,12 +7,10 @@ RSpec.describe WaterDrop do
     let(:set_logger) { double }
 
     it 'returns default null logger instnace' do
-      allow(described_class.instance_variable_get(:@logger)) { nil }
       expect(described_class.logger).to be_a(Logger)
     end
 
     it 'returns set logger' do
-      allow(described_class.instance_variable_get(:@logger)) { set_logger }
       expect(described_class).to receive(:logger).and_return(set_logger)
       described_class.logger
     end

--- a/spec/lib/water_drop_spec.rb
+++ b/spec/lib/water_drop_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe WaterDrop do
 
     it 'returns default null logger instnace' do
       allow(described_class.instance_variable_get(:@logger)) { nil }
-      expect(described_class.logger).to be_a(NullLogger)
+      expect(described_class.logger).to be_a(Logger)
     end
 
     it 'returns set logger' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,7 @@ require 'water_drop'
 WaterDrop.setup do |config|
   config.deliver = true
   config.kafka.seed_brokers = %w[kafka://localhost:9092]
+  config.logger = Logger.new(File.join(WaterDrop.gem_root, 'log', 'test.log'))
 end
 
 WaterDrop.monitor.subscribe(WaterDrop::Instrumentation::StdoutListener)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
   simplecov
 ].each(&method(:require))
 
-# Don't include unnecessary stuff into rcov
+# Don't include unnecessary stuff into coverage
 SimpleCov.start do
   %w[
     .bundle

--- a/waterdrop.gemspec
+++ b/waterdrop.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-configurable', '~> 0.8'
   spec.add_dependency 'dry-monitor', '~> 0.3'
   spec.add_dependency 'dry-validation', '~> 0.11'
-  spec.add_dependency 'null-logger', '~> 0.1'
   spec.add_dependency 'ruby-kafka', '>= 0.7.1'
 
   spec.required_ruby_version = '>= 2.3.0'


### PR DESCRIPTION
This PR:

- adds the `sasl_oauth_token_provider` support
- removes the production dependency on the null logger by using the stdout logger as default with warn and setting the file as a target for running specs
- fixes some typos

This way of handling logger is much better: there won't be a case when someone unexperienced does an integration and sees nothing when running.