### PR TITLE
Expose setting to optionally verify hostname on ssl certs

### DIFF
--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -94,6 +94,8 @@ module WaterDrop
       # option ssl_ca_certs_from_system [Boolean] Use the CA certs from your system's default
       #   certificate store
       setting :ssl_ca_certs_from_system, false
+      # option ssl_verify_hostname [Boolean] Verify the hostname for client certs
+      setting :ssl_verify_hostname, true
       # option ssl_client_cert [String, nil] SSL client certificate
       setting :ssl_client_cert, nil
       # option ssl_client_cert_key [String, nil] SSL client certificate password

--- a/lib/water_drop/contracts/config.rb
+++ b/lib/water_drop/contracts/config.rb
@@ -83,6 +83,7 @@ module WaterDrop
             optional(encryption_attribute).maybe(:str?)
           end
 
+          optional(:ssl_verify_hostname).maybe(:bool?)
           optional(:ssl_ca_certs_from_system).maybe(:bool?)
           optional(:sasl_over_ssl).maybe(:bool?)
           optional(:sasl_oauth_token_provider).value(:any)

--- a/spec/lib/water_drop/contracts/config_spec.rb
+++ b/spec/lib/water_drop/contracts/config_spec.rb
@@ -865,6 +865,14 @@ RSpec.describe WaterDrop::Contracts::Config do
     end
   end
 
+  context 'when we validate ssl_verify_hostname' do
+    context 'when ssl_verify_hostname is not a bool' do
+      before { config[:kafka][:ssl_verify_hostname] = 2 }
+
+      it { expect(contract.call(config)).not_to be_success }
+    end
+  end
+
   context 'when we validate sasl_over_ssl' do
     context 'when sasl_over_ssl is not a bool' do
       before { config[:kafka][:sasl_over_ssl] = 2 }


### PR DESCRIPTION
maintains parity with karafka 1.3.0, which already supports configuring `ssl_verify_hostname` 

When we try to upgrade to karafka 1.3.0, our application cannot connect to Kafka in Heroku to publish messages.

See following PRs for additional context:
https://github.com/zendesk/ruby-kafka/pull/733
https://github.com/karafka/karafka/pull/512