### PR TITLE
validate bootstrap.servers format

### DIFF
--- a/config/errors.yml
+++ b/config/errors.yml
@@ -4,3 +4,5 @@ en:
       invalid_key_type: all keys need to be of type String
       invalid_value_type: all values need to be of type String
       max_payload_size: is more than `max_payload_size` config value
+      bootstrap_servers_must_be_filled: bootstrap.servers must be filled
+      invalid_seed_brokers_format: the expected format for 'bootstrap.servers' value is host1:port1,host2:port2, without explicit URI scheme

--- a/lib/water_drop/contracts/config.rb
+++ b/lib/water_drop/contracts/config.rb
@@ -30,7 +30,7 @@ module WaterDrop
           next
         end
 
-        seed_broker_has_valid_format = ->(seed_broker) do
+        seed_broker_has_valid_format = lambda do |seed_broker|
           SEED_BROKER_FORMAT_REGEXP.match?(seed_broker)
         end
         unless bootstrap_servers.split(SEED_BROKERS_SEPARATOR).all?(&seed_broker_has_valid_format)

--- a/lib/water_drop/contracts/config.rb
+++ b/lib/water_drop/contracts/config.rb
@@ -3,8 +3,11 @@
 module WaterDrop
   module Contracts
     # Contract with validation rules for WaterDrop configuration details
-    SEED_BROKERS_SEPARATOR = ",".freeze
-    SEED_BROKER_FORMAT_REGEXP = /(?=^((?!\:\/\/).)*$).+\:\d+/.freeze
+
+    # Use comma as a separator between multiple seed brokers
+    SEED_BROKERS_SEPARATOR = ','
+    # Ensure valid format of each seed broker so that rdkafka doesn't fail silently
+    SEED_BROKER_FORMAT_REGEXP = %r{(?=^((?!\:\/\/).)*$).+\:\d+}.freeze
     private_constant :SEED_BROKERS_SEPARATOR, :SEED_BROKER_FORMAT_REGEXP
 
     class Config < Dry::Validation::Contract
@@ -20,10 +23,15 @@ module WaterDrop
 
       rule(:kafka) do
         next unless value.is_a?(Hash)
-        bootstrap_servers = value.symbolize_keys[:"bootstrap.servers"].to_s
 
-        key.failure(:bootstrap_servers_must_be_filled) and next if bootstrap_servers.to_s.empty?
-        if !bootstrap_servers.split(SEED_BROKERS_SEPARATOR).all? { |seed_broker| SEED_BROKER_FORMAT_REGEXP.match?(seed_broker) }
+        bootstrap_servers = value.symbolize_keys[:"bootstrap.servers"].to_s
+        if bootstrap_servers.to_s.empty?
+          key.failure(:bootstrap_servers_must_be_filled)
+          next
+        end
+
+        seed_broker_has_valid_format = ->(seed_broker) { SEED_BROKER_FORMAT_REGEXP.match?(seed_broker) }
+        unless bootstrap_servers.split(SEED_BROKERS_SEPARATOR).all?(&seed_broker_has_valid_format)
           key.failure(:invalid_seed_brokers_format)
         end
       end

--- a/lib/water_drop/contracts/config.rb
+++ b/lib/water_drop/contracts/config.rb
@@ -30,7 +30,9 @@ module WaterDrop
           next
         end
 
-        seed_broker_has_valid_format = ->(seed_broker) { SEED_BROKER_FORMAT_REGEXP.match?(seed_broker) }
+        seed_broker_has_valid_format = ->(seed_broker) do
+          SEED_BROKER_FORMAT_REGEXP.match?(seed_broker)
+        end
         unless bootstrap_servers.split(SEED_BROKERS_SEPARATOR).all?(&seed_broker_has_valid_format)
           key.failure(:invalid_seed_brokers_format)
         end

--- a/spec/lib/water_drop/config_spec.rb
+++ b/spec/lib/water_drop/config_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe WaterDrop::Config do
 
     context 'when configuration is valid' do
       it 'not raise ConfigurationInvalidError exception' do
-        expect { config.setup { |config| config.kafka = { rand => rand } } }
+        expect { config.setup { |config| config.kafka = { 'bootstrap.servers' => 'localhost:9092', rand => rand } } }
           .not_to raise_error
       end
     end

--- a/spec/lib/water_drop/config_spec.rb
+++ b/spec/lib/water_drop/config_spec.rb
@@ -18,8 +18,12 @@ RSpec.describe WaterDrop::Config do
     end
 
     context 'when configuration is valid' do
+      let(:kafka_config) do
+        { 'bootstrap.servers' => 'localhost:9092', rand => rand }
+      end
+
       it 'not raise ConfigurationInvalidError exception' do
-        expect { config.setup { |config| config.kafka = { 'bootstrap.servers' => 'localhost:9092', rand => rand } } }
+        expect { config.setup { |config| config.kafka = kafka_config } }
           .not_to raise_error
       end
     end

--- a/spec/lib/water_drop/contracts/config_spec.rb
+++ b/spec/lib/water_drop/contracts/config_spec.rb
@@ -111,26 +111,30 @@ RSpec.describe WaterDrop::Contracts::Config do
       it { expect(contract_result).not_to be_success }
       it { expect(contract_errors[:kafka]).to eq ['bootstrap.servers must be filled'] }
     end
-#
-    context 'when bootstrap.servers contains a single seed broker with something that does not look like URI' do
+
+    context 'when bootstrap.servers contains a single seed broker with something that does not
+    look like URI' do
       before { config[:kafka] = { 'bootstrap.servers': 1234 } }
 
       it { expect(contract_result).not_to be_success }
-      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' value is host1:port1,host2:port2, without explicit URI scheme'] }
+      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' ' +
+        'value is host1:port1,host2:port2, without explicit URI scheme'] }
     end
 
     context 'when bootstrap.servers contains a single seed broker with explicit URI scheme' do
       before { config[:kafka] = { 'bootstrap.servers': 'kafka://127.0.0.1:9092' } }
 
       it { expect(contract_result).not_to be_success }
-      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' value is host1:port1,host2:port2, without explicit URI scheme'] }
+      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' ' +
+        'value is host1:port1,host2:port2, without explicit URI scheme'] }
     end
 
     context 'when bootstrap.servers contains a single seed broker without a port' do
       before { config[:kafka] = { 'bootstrap.servers': '127.0.0.1' } }
 
       it { expect(contract_result).not_to be_success }
-      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' value is host1:port1,host2:port2, without explicit URI scheme'] }
+      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' ' +
+        'value is host1:port1,host2:port2, without explicit URI scheme'] }
     end
 
     context 'when bootstrap.servers contains a valid single seed broker' do
@@ -140,21 +144,26 @@ RSpec.describe WaterDrop::Contracts::Config do
       it { expect(contract_errors).to be_empty }
     end
 
-    context 'when bootstrap.servers contains multiple seed brokers separated by a comma with at least one of them with explicit URI scheme' do
+    context 'when bootstrap.servers contains multiple seed brokers separated by a comma with at
+    least one of them with explicit URI scheme' do
       before { config[:kafka] = { 'bootstrap.servers': '127.0.0.1:9092,kafka://127.0.0.1:9093' } }
 
       it { expect(contract_result).not_to be_success }
-      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' value is host1:port1,host2:port2, without explicit URI scheme'] }
+      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' ' +
+        'value is host1:port1,host2:port2, without explicit URI scheme'] }
     end
 
-    context 'when bootstrap.servers contains multiple seed brokers separated by a comma with at least one of them missing a port' do
+    context 'when bootstrap.servers contains multiple seed brokers separated by a comma with at
+    least one of them missing a port' do
       before { config[:kafka] = { 'bootstrap.servers': '127.0.0.1,kafka:9092' } }
 
       it { expect(contract_result).not_to be_success }
-      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' value is host1:port1,host2:port2, without explicit URI scheme'] }
+      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' ' +
+        'value is host1:port1,host2:port2, without explicit URI scheme'] }
     end
 
-    context 'when bootstrap.servers contains a single seed brokers separated by a comma and none of them have explicit URI scheme and all of them contain a port' do
+    context 'when bootstrap.servers contains a single seed brokers separated by a comma and none
+    of them have explicit URI scheme and all of them contain a port' do
       before { config[:kafka] = { 'bootstrap.servers': '127.0.0.1:9093,kafka:9092' } }
 
       it { expect(contract_result).to be_success }

--- a/spec/lib/water_drop/contracts/config_spec.rb
+++ b/spec/lib/water_drop/contracts/config_spec.rb
@@ -97,6 +97,71 @@ RSpec.describe WaterDrop::Contracts::Config do
     it { expect(contract_errors[:kafka]).not_to be_empty }
   end
 
+  context 'when kafka hash is present' do
+    context 'when bootstrap.servers is nil' do
+      before { config[:kafka] = { 'bootstrap.servers': nil } }
+
+      it { expect(contract_result).not_to be_success }
+      it { expect(contract_errors[:kafka]).to eq ['bootstrap.servers must be filled'] }
+    end
+
+    context 'when bootstrap.servers is an empty string' do
+      before { config[:kafka] = { 'bootstrap.servers': '' } }
+
+      it { expect(contract_result).not_to be_success }
+      it { expect(contract_errors[:kafka]).to eq ['bootstrap.servers must be filled'] }
+    end
+#
+    context 'when bootstrap.servers contains a single seed broker with something that does not look like URI' do
+      before { config[:kafka] = { 'bootstrap.servers': 1234 } }
+
+      it { expect(contract_result).not_to be_success }
+      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' value is host1:port1,host2:port2, without explicit URI scheme'] }
+    end
+
+    context 'when bootstrap.servers contains a single seed broker with explicit URI scheme' do
+      before { config[:kafka] = { 'bootstrap.servers': 'kafka://127.0.0.1:9092' } }
+
+      it { expect(contract_result).not_to be_success }
+      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' value is host1:port1,host2:port2, without explicit URI scheme'] }
+    end
+
+    context 'when bootstrap.servers contains a single seed broker without a port' do
+      before { config[:kafka] = { 'bootstrap.servers': '127.0.0.1' } }
+
+      it { expect(contract_result).not_to be_success }
+      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' value is host1:port1,host2:port2, without explicit URI scheme'] }
+    end
+
+    context 'when bootstrap.servers contains a valid single seed broker' do
+      before { config[:kafka] = { 'bootstrap.servers': '127.0.0.1:9092' } }
+
+      it { expect(contract_result).to be_success }
+      it { expect(contract_errors).to be_empty }
+    end
+
+    context 'when bootstrap.servers contains multiple seed brokers separated by a comma with at least one of them with explicit URI scheme' do
+      before { config[:kafka] = { 'bootstrap.servers': '127.0.0.1:9092,kafka://127.0.0.1:9093' } }
+
+      it { expect(contract_result).not_to be_success }
+      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' value is host1:port1,host2:port2, without explicit URI scheme'] }
+    end
+
+    context 'when bootstrap.servers contains multiple seed brokers separated by a comma with at least one of them missing a port' do
+      before { config[:kafka] = { 'bootstrap.servers': '127.0.0.1,kafka:9092' } }
+
+      it { expect(contract_result).not_to be_success }
+      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' value is host1:port1,host2:port2, without explicit URI scheme'] }
+    end
+
+    context 'when bootstrap.servers contains a single seed brokers separated by a comma and none of them have explicit URI scheme and all of them contain a port' do
+      before { config[:kafka] = { 'bootstrap.servers': '127.0.0.1:9093,kafka:9092' } }
+
+      it { expect(contract_result).to be_success }
+      it { expect(contract_errors).to be_empty }
+    end
+  end
+
   context 'when max_payload_size is nil' do
     before { config[:max_payload_size] = nil }
 

--- a/spec/lib/water_drop/contracts/config_spec.rb
+++ b/spec/lib/water_drop/contracts/config_spec.rb
@@ -98,6 +98,11 @@ RSpec.describe WaterDrop::Contracts::Config do
   end
 
   context 'when kafka hash is present' do
+    let(:invalid_format_error_message) do
+      'the expected format for \'bootstrap.servers\' value is host1:port1,host2:port2, ' \
+      'without explicit URI scheme'
+    end
+
     context 'when bootstrap.servers is nil' do
       before { config[:kafka] = { 'bootstrap.servers': nil } }
 
@@ -117,24 +122,21 @@ RSpec.describe WaterDrop::Contracts::Config do
       before { config[:kafka] = { 'bootstrap.servers': 1234 } }
 
       it { expect(contract_result).not_to be_success }
-      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' ' +
-        'value is host1:port1,host2:port2, without explicit URI scheme'] }
+      it { expect(contract_errors[:kafka]).to eq [invalid_format_error_message] }
     end
 
     context 'when bootstrap.servers contains a single seed broker with explicit URI scheme' do
       before { config[:kafka] = { 'bootstrap.servers': 'kafka://127.0.0.1:9092' } }
 
       it { expect(contract_result).not_to be_success }
-      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' ' +
-        'value is host1:port1,host2:port2, without explicit URI scheme'] }
+      it { expect(contract_errors[:kafka]).to eq [invalid_format_error_message] }
     end
 
     context 'when bootstrap.servers contains a single seed broker without a port' do
       before { config[:kafka] = { 'bootstrap.servers': '127.0.0.1' } }
 
       it { expect(contract_result).not_to be_success }
-      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' ' +
-        'value is host1:port1,host2:port2, without explicit URI scheme'] }
+      it { expect(contract_errors[:kafka]).to eq [invalid_format_error_message] }
     end
 
     context 'when bootstrap.servers contains a valid single seed broker' do
@@ -149,8 +151,7 @@ RSpec.describe WaterDrop::Contracts::Config do
       before { config[:kafka] = { 'bootstrap.servers': '127.0.0.1:9092,kafka://127.0.0.1:9093' } }
 
       it { expect(contract_result).not_to be_success }
-      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' ' +
-        'value is host1:port1,host2:port2, without explicit URI scheme'] }
+      it { expect(contract_errors[:kafka]).to eq [invalid_format_error_message] }
     end
 
     context 'when bootstrap.servers contains multiple seed brokers separated by a comma with at
@@ -158,8 +159,7 @@ RSpec.describe WaterDrop::Contracts::Config do
       before { config[:kafka] = { 'bootstrap.servers': '127.0.0.1,kafka:9092' } }
 
       it { expect(contract_result).not_to be_success }
-      it { expect(contract_errors[:kafka]).to eq ['the expected format for \'bootstrap.servers\' ' +
-        'value is host1:port1,host2:port2, without explicit URI scheme'] }
+      it { expect(contract_errors[:kafka]).to eq [invalid_format_error_message] }
     end
 
     context 'when bootstrap.servers contains a single seed brokers separated by a comma and none


### PR DESCRIPTION
Solves https://github.com/karafka/waterdrop/issues/113

`dry` wasn't really cooperative with a dot in the attribute name ("bootstrap.servers") and `rule(kafka: "bootstrap.servers")` was raising an error about defining a rule for a non-existent attribute which probably conflicts with a dot notation used for nesting in dry. To avoid some transformations on a config hash, I simply defined the rule for `kafka` attribute itself. A bit ugly, but does the job :P 