### PR TITLE
make client fetching and closing thread safe

### DIFF
--- a/lib/water_drop/producer.rb
+++ b/lib/water_drop/producer.rb
@@ -96,6 +96,10 @@ module WaterDrop
         ) do
           @status.closing!
 
+          # No need for auto-gc if everything got closed by us
+          # This should be used only in case a producer was not closed properly and forgotten
+          ObjectSpace.undefine_finalizer(self)
+
           # Flush has it's own buffer mutex but even if it is blocked, flushing can still happen
           # as we close the client after the flushing (even if blocked by the mutex)
           flush(false)
@@ -106,10 +110,6 @@ module WaterDrop
 
           @status.closed!
         end
-
-        # No need for auto-gc if everything got closed by us
-        # This should be used only in case a producer was not closed properly and forgotten
-        ObjectSpace.undefine_finalizer(self)
       end
     end
 

--- a/lib/water_drop/producer.rb
+++ b/lib/water_drop/producer.rb
@@ -78,9 +78,11 @@ module WaterDrop
         ObjectSpace.define_finalizer(self, proc { close })
 
         @pid = Process.pid
-        @status.connected!
         @client = Builder.new.call(self, @config)
+        @status.connected!
       end
+
+      @client
     end
 
     # Flushes the buffers in a sync way and closes the producer

--- a/lib/water_drop/producer.rb
+++ b/lib/water_drop/producer.rb
@@ -22,7 +22,11 @@ module WaterDrop
     # @param block [Proc] configuration block
     # @return [Producer] producer instance
     def initialize(&block)
-      @mutex = Mutex.new
+      # Mutex for managing the internal buffers that can be flushed
+      @buffer_mutex = Mutex.new
+      @connecting_mutex = Mutex.new
+      @closing_mutex = Mutex.new
+
       @status = Status.new
       @messages = Concurrent::Array.new
 
@@ -53,45 +57,59 @@ module WaterDrop
     # @note It is not recommended to fork a producer that is already in use so in case of
     #   bootstrapping a cluster, it's much better to fork configured but not used producers
     def client
-      return @client if @pid == Process.pid
+      return @client if @client && @pid == Process.pid
 
-      # We should raise an error when trying to use a producer from a fork, that is already
-      # connected to Kafka. We allow forking producers only before they are used
-      raise Errors::ProducerUsedInParentProcess, Process.pid if @status.connected?
+      # Don't allow to obtain a client reference for a producer that was not configured
+      raise Errors::ProducerNotConfiguredError, id if @status.initial?
 
-      # We undefine all the finalizers, in case it was a fork, so the finalizers from the parent
-      # process don't leak
-      ObjectSpace.undefine_finalizer(self)
-      # Finalizer tracking is needed for handling shutdowns gracefully.
-      # I don't expect everyone to remember about closing all the producers all the time, thus
-      # this approach is better. Although it is still worth keeping in mind, that this will
-      # block GC from removing a no longer used producer unless closed properly
-      ObjectSpace.define_finalizer(self, proc { close })
+      @connecting_mutex.synchronize do
+        return @client if @client && @pid == Process.pid
 
-      @pid = Process.pid
-      @status.connected!
-      @client = Builder.new.call(self, @config)
+        # We should raise an error when trying to use a producer from a fork, that is already
+        # connected to Kafka. We allow forking producers only before they are used
+        raise Errors::ProducerUsedInParentProcess, Process.pid if @status.connected?
+
+        # We undefine all the finalizers, in case it was a fork, so the finalizers from the parent
+        # process don't leak
+        ObjectSpace.undefine_finalizer(self)
+        # Finalizer tracking is needed for handling shutdowns gracefully.
+        # I don't expect everyone to remember about closing all the producers all the time, thus
+        # this approach is better. Although it is still worth keeping in mind, that this will
+        # block GC from removing a no longer used producer unless closed properly
+        ObjectSpace.define_finalizer(self, proc { close })
+
+        @pid = Process.pid
+        @status.connected!
+        @client = Builder.new.call(self, @config)
+      end
     end
 
     # Flushes the buffers in a sync way and closes the producer
     def close
-      return unless @status.active?
+      @closing_mutex.synchronize do
+        return unless @status.active?
 
-      @monitor.instrument(
-        'producer.closed',
-        producer: self
-      ) do
-        @status.closing!
+        @monitor.instrument(
+          'producer.closed',
+          producer: self
+        ) do
+          @status.closing!
 
-        flush(false)
+          # Flush has it's own buffer mutex but even if it is blocked, flushing can still happen
+          # as we close the client after the flushing (even if blocked by the mutex)
+          flush(false)
 
-        client.close
-        @status.closed!
+          # We should not close the client in several threads the same time
+          # It is safe to run it several times but not exactly the same moment
+          client.close
+
+          @status.closed!
+        end
+
+        # No need for auto-gc if everything got closed by us
+        # This should be used only in case a producer was not closed properly and forgotten
+        ObjectSpace.undefine_finalizer(self)
       end
-
-      # No need for auto-gc if everything got closed by us
-      # This should be used only in case a producer was not closed properly and forgotten
-      ObjectSpace.undefine_finalizer(self)
     end
 
     # Ensures that we don't run any operations when the producer is not configured or when it

--- a/lib/water_drop/producer.rb
+++ b/lib/water_drop/producer.rb
@@ -22,7 +22,6 @@ module WaterDrop
     # @param block [Proc] configuration block
     # @return [Producer] producer instance
     def initialize(&block)
-      # Mutex for managing the internal buffers that can be flushed
       @buffer_mutex = Mutex.new
       @connecting_mutex = Mutex.new
       @closing_mutex = Mutex.new

--- a/lib/water_drop/producer/buffer.rb
+++ b/lib/water_drop/producer/buffer.rb
@@ -87,7 +87,7 @@ module WaterDrop
         data_for_dispatch = nil
         dispatched = []
 
-        @mutex.synchronize do
+        @buffer_mutex.synchronize do
           data_for_dispatch = @messages
           @messages = Concurrent::Array.new
         end

--- a/spec/lib/water_drop/producer_spec.rb
+++ b/spec/lib/water_drop/producer_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe WaterDrop::Producer do
       end
     end
 
-
     context 'when client is already connected' do
       let(:producer) { build(:producer) }
 

--- a/spec/lib/water_drop/producer_spec.rb
+++ b/spec/lib/water_drop/producer_spec.rb
@@ -47,9 +47,18 @@ RSpec.describe WaterDrop::Producer do
   describe '#client' do
     subject(:client) { producer.client }
 
-    let(:producer) { build(:producer) }
+    context 'when producer is not configured' do
+      let(:expected_error) { WaterDrop::Errors::ProducerNotConfiguredError }
+
+      it 'expect not to allow to build client' do
+        expect { client }.to raise_error expected_error
+      end
+    end
+
 
     context 'when client is already connected' do
+      let(:producer) { build(:producer) }
+
       before { producer.client }
 
       context 'when called from a fork' do
@@ -67,6 +76,8 @@ RSpec.describe WaterDrop::Producer do
     end
 
     context 'when client is not connected' do
+      let(:producer) { build(:producer) }
+
       context 'when called from a fork' do
         before { allow(Process).to receive(:pid).and_return(-1) }
 


### PR DESCRIPTION
This PR fixes the concurrency problem that could occur when:

- 1 thread would be setting up configuration while another would try to fetch a client (crazy but possible)
- 1 thread would try to close the producer and another would try to do the same (librdkafka crashes in that case)
- after fork: 1 thread would try to set a client and another one would try to do the same when pid is already set BUT the client is not

close https://github.com/karafka/waterdrop/issues/138