### PR TITLE
Pass `options` as kwargs from SyncProducer to DeliveryBoy

### DIFF
--- a/lib/water_drop/sync_producer.rb
+++ b/lib/water_drop/sync_producer.rb
@@ -16,7 +16,7 @@ module WaterDrop
       validate!(options)
       return unless WaterDrop.config.deliver
 
-      DeliveryBoy.deliver(message, options)
+      DeliveryBoy.deliver(message, **options)
     rescue Kafka::Error => e
       graceful_attempt?(attempts_count, message, options, e) ? retry : raise(e)
     end

--- a/spec/lib/water_drop/async_producer_spec.rb
+++ b/spec/lib/water_drop/async_producer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe WaterDrop::AsyncProducer do
         before { allow(WaterDrop.config).to receive(:deliver).and_return(true) }
 
         it 'expect to pass to ruby-kafka' do
-          expect(DeliveryBoy).to receive(:deliver_async!).with(message, topic: topic)
+          expect(DeliveryBoy).to receive(:deliver_async!).with(message, topic: topic).and_call_original
           expect { delivery }.not_to raise_error
         end
       end
@@ -43,7 +43,7 @@ RSpec.describe WaterDrop::AsyncProducer do
         end
 
         it 'expect to run with a silent delivery method on ruby-kafka' do
-          expect(DeliveryBoy).to receive(:deliver_async).with(message, topic: topic)
+          expect(DeliveryBoy).to receive(:deliver_async).with(message, topic: topic).and_call_original
           expect { delivery }.not_to raise_error
         end
       end

--- a/spec/lib/water_drop/sync_producer_spec.rb
+++ b/spec/lib/water_drop/sync_producer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe WaterDrop::SyncProducer do
         before { allow(WaterDrop.config).to receive(:deliver).and_return(true) }
 
         it 'expect to pass to ruby-kafka' do
-          expect(DeliveryBoy).to receive(:deliver).with(message, topic: topic)
+          expect(DeliveryBoy).to receive(:deliver).with(message, topic: topic).and_call_original
           expect { delivery }.not_to raise_error
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,9 @@ RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
+
+  config.before(:all) { DeliveryBoy.test_mode! }
+  config.before { DeliveryBoy.testing.clear }
 end
 
 require 'water_drop'


### PR DESCRIPTION
Fixes ruby-3.0 compat