### PR TITLE
fix binded finalizer warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Remove Ruby 2.5 support and update minimum Ruby requirement to 2.6
+- Fix the `finalizer references object to be finalized` warning issued with 3.0
 
 ## 2.0.0 (2020-12-13)
 - Redesign of the whole API (see `README.md` for the use-cases and the current API)

--- a/lib/water_drop/producer.rb
+++ b/lib/water_drop/producer.rb
@@ -99,7 +99,7 @@ module WaterDrop
 
           # No need for auto-gc if everything got closed by us
           # This should be used only in case a producer was not closed properly and forgotten
-          ObjectSpace.undefine_finalizer(self)
+          ObjectSpace.undefine_finalizer(id)
 
           # Flush has it's own buffer mutex but even if it is blocked, flushing can still happen
           # as we close the client after the flushing (even if blocked by the mutex)

--- a/lib/water_drop/producer.rb
+++ b/lib/water_drop/producer.rb
@@ -70,12 +70,13 @@ module WaterDrop
 
         # We undefine all the finalizers, in case it was a fork, so the finalizers from the parent
         # process don't leak
-        ObjectSpace.undefine_finalizer(self)
+        ObjectSpace.undefine_finalizer(+'')
         # Finalizer tracking is needed for handling shutdowns gracefully.
         # I don't expect everyone to remember about closing all the producers all the time, thus
         # this approach is better. Although it is still worth keeping in mind, that this will
-        # block GC from removing a no longer used producer unless closed properly
-        ObjectSpace.define_finalizer(self, proc { close })
+        # block GC from removing a no longer used producer unless closed properly but at least
+        # won't crash the VM upon closing the process
+        ObjectSpace.define_finalizer(+'', proc { close })
 
         @pid = Process.pid
         @client = Builder.new.call(self, @config)

--- a/lib/water_drop/producer.rb
+++ b/lib/water_drop/producer.rb
@@ -70,13 +70,13 @@ module WaterDrop
 
         # We undefine all the finalizers, in case it was a fork, so the finalizers from the parent
         # process don't leak
-        ObjectSpace.undefine_finalizer(+'')
+        ObjectSpace.undefine_finalizer(id)
         # Finalizer tracking is needed for handling shutdowns gracefully.
         # I don't expect everyone to remember about closing all the producers all the time, thus
         # this approach is better. Although it is still worth keeping in mind, that this will
         # block GC from removing a no longer used producer unless closed properly but at least
         # won't crash the VM upon closing the process
-        ObjectSpace.define_finalizer(+'', proc { close })
+        ObjectSpace.define_finalizer(id, proc { close })
 
         @pid = Process.pid
         @client = Builder.new.call(self, @config)


### PR DESCRIPTION
This PR uses producer id to bind the finalizer, that way we do not reference it in the definition, skipping the warning. It does not change how and when it kicks in.