### PR TITLE
Close producers in specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.0.2 (2021-08-13)
 - Add support for `partition_key`
 - Switch license from `LGPL-3.0` to  `MIT`
-- Switch flushing on close to sync and add `0.2` of a second to finalize rdkafka producer
+- Switch flushing on close to sync
 
 ## 2.0.1 (2021-06-05)
 - Remove Ruby 2.5 support and update minimum Ruby requirement to 2.6

--- a/lib/water_drop/producer.rb
+++ b/lib/water_drop/producer.rb
@@ -109,9 +109,6 @@ module WaterDrop
           # It is safe to run it several times but not exactly the same moment
           client.close
 
-          # Give rdkafka enough time to close background producer
-          sleep(0.2)
-
           @status.closed!
         end
       end

--- a/spec/lib/water_drop/producer/async_spec.rb
+++ b/spec/lib/water_drop/producer/async_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe WaterDrop::Producer::Async do
   subject(:producer) { build(:producer) }
 
+  after { producer.close }
+
   describe '#produce_async' do
     subject(:delivery) { producer.produce_async(message) }
 

--- a/spec/lib/water_drop/producer/buffer_spec.rb
+++ b/spec/lib/water_drop/producer/buffer_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe WaterDrop::Producer::Buffer do
   subject(:producer) { build(:producer) }
 
+  after { producer.close }
+
   describe '#buffer' do
     subject(:buffering) { producer.buffer(message) }
 

--- a/spec/lib/water_drop/producer/builder_spec.rb
+++ b/spec/lib/water_drop/producer/builder_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe WaterDrop::Producer::Builder do
     producer_config.config
   end
 
+  after { producer.close }
+
   it { expect(client).to be_a(Rdkafka::Producer) }
   it { expect(client.delivery_callback).to be_a(Proc) }
 

--- a/spec/lib/water_drop/producer/sync_spec.rb
+++ b/spec/lib/water_drop/producer/sync_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe WaterDrop::Producer::Sync do
   subject(:producer) { build(:producer) }
 
+  after { producer.close }
+
   describe '#produce_sync' do
     subject(:delivery) { producer.produce_sync(message) }
 

--- a/spec/lib/water_drop/producer_spec.rb
+++ b/spec/lib/water_drop/producer_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe WaterDrop::Producer do
   subject(:producer) { described_class.new }
 
+  after { producer.close }
+
   describe '#initialize' do
     context 'when we initialize without a setup' do
       it { expect { producer }.not_to raise_error }


### PR DESCRIPTION
This PR closes all the producers prior to VM closing. This should ensure we do not have any weird segmentation faults as things are done the correct way.