### PR TITLE
do not close never used client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.3 (Unreleased)
 - Remove rdkafka patch in favour of spec topic pre-creation
+- Do not close client that was never used upon closing producer
 
 ## 2.0.2 (2021-08-13)
 - Add support for `partition_key`

--- a/lib/water_drop/producer.rb
+++ b/lib/water_drop/producer.rb
@@ -107,7 +107,9 @@ module WaterDrop
 
           # We should not close the client in several threads the same time
           # It is safe to run it several times but not exactly the same moment
-          client.close
+          # We also mark it as closed only if it was connected, if not, it would trigger a new
+          # connection that anyhow would be immediately closed
+          client.close if @client
 
           @status.closed!
         end


### PR DESCRIPTION
This PR optimizes closing process. When producer was not used, connection to Kafka was not established via client. If so, there is no need to close it.