### PR TITLE
v1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # WaterDrop changelog
 
-## Unreleased
+## 1.4.3 (2021-09-29)
 - Remove Ruby 2.5 support and update minimum Ruby requirement to 2.6
 - fix `dry-configurable` deprecation warnings for default value as positional argument
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (1.4.2)
+    waterdrop (1.4.3)
       delivery_boy (>= 0.2, < 2.x)
       dry-configurable (~> 0.8)
       dry-monitor (~> 0.3)

--- a/lib/water_drop/version.rb
+++ b/lib/water_drop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '1.4.2'
+  VERSION = '1.4.3'
 end


### PR DESCRIPTION
- Remove Ruby 2.5 support and update minimum Ruby requirement to 2.6
- fix `dry-configurable` deprecation warnings for default value as positional argument

close https://github.com/karafka/waterdrop/issues/207