### PR TITLE
1.4.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # WaterDrop changelog
 
-## master
+## 1.4.4 (2021-10-30)
 - minimum version of ruby-kafka is now 1.3
-- update gems requirements in the gemspec
+- update gems requirements in the gemspec (nijikon)
 
 ## 1.4.3 (2021-09-29)
 - Remove Ruby 2.5 support and update minimum Ruby requirement to 2.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (1.4.3)
+    waterdrop (1.4.4)
       delivery_boy (>= 0.2, < 2.x)
       dry-configurable (~> 0.13)
       dry-monitor (~> 0.5)

--- a/lib/water_drop/version.rb
+++ b/lib/water_drop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '1.4.3'
+  VERSION = '1.4.4'
 end


### PR DESCRIPTION
- minimum version of ruby-kafka is now 1.3
- update gems requirements in the gemspec (nijikon)