### PR TITLE
Normalize events keys and update StdoutListener 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # WaterDrop changelog
 
+## 2.0.7 (Unreleased)
+- Replace `:producer` with `:producer_id` in events and update `StdoutListener` accordingly. This change aligns all the events in terms of not publishing the whole producer object in the events.
+- Add `error.emitted` into the `StdoutListener`.
+- Enable `StdoutLogger` in specs for additional integration coverage.
+
 ## 2.0.6 (2021-12-01)
 - #218 - Fixes a case, where dispatch of callbacks the same moment a new producer was created could cause a concurrency issue in the manager.
 - Fix some unstable specs.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.0.6)
+    waterdrop (2.0.7)
       concurrent-ruby (>= 1.1)
       dry-configurable (~> 0.13)
       dry-monitor (~> 0.5)

--- a/lib/water_drop/instrumentation/callbacks/error.rb
+++ b/lib/water_drop/instrumentation/callbacks/error.rb
@@ -17,7 +17,7 @@ module WaterDrop
         # Runs the instrumentation monitor with error
         # @param client_name [String] rdkafka client name
         # @param error [Rdkafka::Error] error that occurred
-        # @note If will only instrument on errors of the client of our producer
+        # @note It will only instrument on errors of the client of our producer
         def call(client_name, error)
           # Emit only errors related to our client
           # Same as with statistics (mor explanation there)

--- a/lib/water_drop/instrumentation/stdout_listener.rb
+++ b/lib/water_drop/instrumentation/stdout_listener.rb
@@ -51,7 +51,7 @@ module WaterDrop
         message = event[:message]
 
         info(event, "Buffering of a message to '#{message[:topic]}' topic")
-        debug(event, [message, event[:producer].messages.size])
+        debug(event, [message])
       end
 
       # @param event [Dry::Events::Event] event that happened with the details
@@ -59,7 +59,7 @@ module WaterDrop
         messages = event[:messages]
 
         info(event, "Buffering of #{messages.size} messages")
-        debug(event, [messages, event[:producer].messages.size])
+        debug(event, [messages, messages.size])
       end
 
       # @param event [Dry::Events::Event] event that happened with the details
@@ -99,7 +99,15 @@ module WaterDrop
       # @param event [Dry::Events::Event] event that happened with the details
       def on_producer_closed(event)
         info event, 'Closing producer'
-        debug event, event[:producer].messages.size
+        debug event, ''
+      end
+
+      # @param event [Dry::Events::Event] event that happened with the error details
+      def on_error_emitted(event)
+        error = event[:error]
+
+        error(event, "Background thread error emitted: #{error}")
+        debug(event, '')
       end
 
       private
@@ -107,19 +115,19 @@ module WaterDrop
       # @param event [Dry::Events::Event] event that happened with the details
       # @param log_message [String] message we want to publish
       def debug(event, log_message)
-        @logger.debug("[#{event[:producer].id}] #{log_message}")
+        @logger.debug("[#{event[:producer_id]}] #{log_message}")
       end
 
       # @param event [Dry::Events::Event] event that happened with the details
       # @param log_message [String] message we want to publish
       def info(event, log_message)
-        @logger.info("[#{event[:producer].id}] #{log_message} took #{event[:time]} ms")
+        @logger.info("[#{event[:producer_id]}] #{log_message} took #{event[:time]} ms")
       end
 
       # @param event [Dry::Events::Event] event that happened with the details
       # @param log_message [String] message we want to publish
       def error(event, log_message)
-        @logger.error("[#{event[:producer].id}] #{log_message}")
+        @logger.error("[#{event[:producer_id]}] #{log_message}")
       end
     end
   end

--- a/lib/water_drop/producer.rb
+++ b/lib/water_drop/producer.rb
@@ -106,7 +106,7 @@ module WaterDrop
 
         @monitor.instrument(
           'producer.closed',
-          producer: self
+          producer_id: id
         ) do
           @status.closing!
 

--- a/lib/water_drop/producer/async.rb
+++ b/lib/water_drop/producer/async.rb
@@ -19,7 +19,7 @@ module WaterDrop
 
         @monitor.instrument(
           'message.produced_async',
-          producer: self,
+          producer_id: id,
           message: message
         ) { client.produce(**message) }
       end
@@ -40,7 +40,7 @@ module WaterDrop
 
         @monitor.instrument(
           'messages.produced_async',
-          producer: self,
+          producer_id: id,
           messages: messages
         ) do
           messages.map { |message| client.produce(**message) }

--- a/lib/water_drop/producer/buffer.rb
+++ b/lib/water_drop/producer/buffer.rb
@@ -23,7 +23,7 @@ module WaterDrop
 
         @monitor.instrument(
           'message.buffered',
-          producer: self,
+          producer_id: id,
           message: message
         ) { @messages << message }
       end
@@ -40,7 +40,7 @@ module WaterDrop
 
         @monitor.instrument(
           'messages.buffered',
-          producer: self,
+          producer_id: id,
           messages: messages
         ) do
           messages.each { |message| @messages << message }
@@ -56,7 +56,7 @@ module WaterDrop
 
         @monitor.instrument(
           'buffer.flushed_async',
-          producer: self,
+          producer_id: id,
           messages: @messages
         ) { flush(false) }
       end
@@ -69,7 +69,7 @@ module WaterDrop
 
         @monitor.instrument(
           'buffer.flushed_sync',
-          producer: self,
+          producer_id: id,
           messages: @messages
         ) { flush(true) }
       end
@@ -104,7 +104,7 @@ module WaterDrop
         end
       rescue *RESCUED_ERRORS => e
         key = sync ? 'buffer.flushed_sync.error' : 'buffer.flush_async.error'
-        @monitor.instrument(key, producer: self, error: e, dispatched: dispatched)
+        @monitor.instrument(key, producer_id: id, error: e, dispatched: dispatched)
 
         raise Errors::FlushFailureError.new(dispatched)
       end

--- a/lib/water_drop/producer/sync.rb
+++ b/lib/water_drop/producer/sync.rb
@@ -21,7 +21,7 @@ module WaterDrop
 
         @monitor.instrument(
           'message.produced_sync',
-          producer: self,
+          producer_id: id,
           message: message
         ) do
           client
@@ -49,7 +49,7 @@ module WaterDrop
         ensure_active!
         messages.each { |message| validate_message!(message) }
 
-        @monitor.instrument('messages.produced_sync', producer: self, messages: messages) do
+        @monitor.instrument('messages.produced_sync', producer_id: id, messages: messages) do
           messages
             .map { |message| client.produce(**message) }
             .map! do |handler|

--- a/lib/water_drop/version.rb
+++ b/lib/water_drop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.0.6'
+  VERSION = '2.0.7'
 end

--- a/spec/lib/water_drop/instrumentation/stdout_listener_spec.rb
+++ b/spec/lib/water_drop/instrumentation/stdout_listener_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe_current do
     {
       message: message,
       messages: messages,
-      producer: producer,
+      producer_id: producer.id,
       time: rand(100),
       error: Rdkafka::RdkafkaError,
       dispatched: [messages[0]]
@@ -145,6 +145,16 @@ RSpec.describe_current do
     it { expect(logged_data[0]).to include(producer.id) }
     it { expect(logged_data[0]).to include('INFO') }
     it { expect(logged_data[0]).to include('Closing producer') }
+    it { expect(logged_data[1]).to include(producer.id) }
+    it { expect(logged_data[1]).to include('DEBUG') }
+  end
+
+  describe '#on_error_emitted' do
+    before { listener.on_error_emitted(event) }
+
+    it { expect(logged_data[0]).to include(producer.id) }
+    it { expect(logged_data[0]).to include('ERROR') }
+    it { expect(logged_data[0]).to include('Background thread error emitted') }
     it { expect(logged_data[1]).to include(producer.id) }
     it { expect(logged_data[1]).to include('DEBUG') }
   end

--- a/spec/support/factories/producer.rb
+++ b/spec/support/factories/producer.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     skip_create
 
     deliver { true }
-    logger { Logger.new($stdout, level: Logger::INFO) }
+    logger { Logger.new('/dev/null', level: Logger::DEBUG) }
     max_wait_timeout { 30 }
     kafka do
       {
@@ -17,12 +17,16 @@ FactoryBot.define do
     end
 
     initialize_with do
-      new do |config|
+      instance = new do |config|
         config.deliver = deliver
         config.logger = logger
         config.kafka = kafka
         config.max_wait_timeout = max_wait_timeout
       end
+
+      instance.monitor.subscribe(::WaterDrop::Instrumentation::StdoutListener.new(logger))
+
+      instance
     end
   end
 end


### PR DESCRIPTION
This PR:

- Replaces `:producer` with `:producer_id` in events and update `StdoutListener` accordingly. This change aligns all the events in terms of not publishing the whole producer object in the events here and in Karafka 2.0.
- Add `error.emitted` into the `StdoutListener` tracking.
- Enable `StdoutLogger` in specs for additional integration coverage.
