### PR TITLE
Unify error publisher keys to a single key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # WaterDrop changelog
 
-## 2.0.8 (Unreleased)
+## 2.1.0 (Unreleased)
 - Ruby 3.1 support
 - Change the error notification key from `error.emitted` to `error.occurred`.
 - Normalize error tracking and make all the places publish errors into the same notification endpoint (`error.occurred`).
+- Start semantic versioning WaterDrop.
 
 ## 2.0.7 (2021-12-03)
 - Source code metadata url added to the gemspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # WaterDrop changelog
 
-## Unreleased
--Ruby 3.1 support
+## 2.0.8 (Unreleased)
+- Ruby 3.1 support
+- Change the error notification key from `error.emitted` to `error.occurred`.
+- Normalize error tracking and make all the places publish errors into the same notification endpoint (`error.occurred`).
 
 ## 2.0.7 (2021-12-03)
 - Source code metadata url added to the gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.0.8)
+    waterdrop (2.1.0)
       concurrent-ruby (>= 1.1)
       dry-configurable (~> 0.13)
       dry-monitor (~> 0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.0.7)
+    waterdrop (2.0.8)
       concurrent-ruby (>= 1.1)
       dry-configurable (~> 0.13)
       dry-monitor (~> 0.5)

--- a/README.md
+++ b/README.md
@@ -313,9 +313,9 @@ end
 
 # After you stop your Kafka cluster, you will see a lot of those:
 #
-# Internal error occurred: Local: Broker transport failure (transport)
+# WaterDrop error occurred: Local: Broker transport failure (transport)
 #
-# Internal error occurred: Local: Broker transport failure (transport)
+# WaterDrop error occurred: Local: Broker transport failure (transport)
 ```
 
 ### Forking and potential memory problems

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Note: The metrics returned may not be completely consistent between brokers, top
 
 ### Error notifications
 
-Aside from errors related to publishing messages like `buffer.flushed_async.error`, WaterDrop allows you to listen to errors that occur in its internal background threads. Things like reconnecting to Kafka upon network errors and others unrelated to publishing messages are all available under `error.emitted` notification key. You can subscribe to this event to ensure your setup is healthy and without any problems that would otherwise go unnoticed as long as messages are delivered.
+WaterDrop allows you to listen to all errors that occur while producing messages and in its internal background threads. Things like reconnecting to Kafka upon network errors and others unrelated to publishing messages are all available under `error.occurred` notification key. You can subscribe to this event to ensure your setup is healthy and without any problems that would otherwise go unnoticed as long as messages are delivered.
 
 ```ruby
 producer = WaterDrop::Producer.new do |config|
@@ -298,10 +298,10 @@ producer = WaterDrop::Producer.new do |config|
   config.kafka = { 'bootstrap.servers': 'localhost:9090' }
 end
 
-producer.monitor.subscribe('error.emitted') do |event|
+producer.monitor.subscribe('error.occurred') do |event|
   error = event[:error]
 
-  p "Internal error occurred: #{error}"
+  p "WaterDrop error occurred: #{error}"
 end
 
 # Run this code without Kafka cluster

--- a/lib/water_drop/instrumentation/callbacks/error.rb
+++ b/lib/water_drop/instrumentation/callbacks/error.rb
@@ -24,9 +24,10 @@ module WaterDrop
           return unless @client_name == client_name
 
           @monitor.instrument(
-            'error.emitted',
+            'error.occurred',
+            error: error,
             producer_id: @producer_id,
-            error: error
+            type: 'librdkafka.error'
           )
         end
       end

--- a/lib/water_drop/instrumentation/monitor.rb
+++ b/lib/water_drop/instrumentation/monitor.rb
@@ -24,13 +24,11 @@ module WaterDrop
         messages.buffered
 
         buffer.flushed_async
-        buffer.flushed_async.error
         buffer.flushed_sync
-        buffer.flushed_sync.error
 
         statistics.emitted
 
-        error.emitted
+        error.occurred
       ].freeze
 
       private_constant :EVENTS

--- a/lib/water_drop/instrumentation/stdout_listener.rb
+++ b/lib/water_drop/instrumentation/stdout_listener.rb
@@ -71,28 +71,10 @@ module WaterDrop
       end
 
       # @param event [Dry::Events::Event] event that happened with the details
-      def on_buffer_flushed_async_error(event)
-        messages = event[:messages]
-        error = event[:error]
-
-        error(event, "Async flushing of #{messages.size} failed due to: #{error}")
-        debug(event, messages)
-      end
-
-      # @param event [Dry::Events::Event] event that happened with the details
       def on_buffer_flushed_sync(event)
         messages = event[:messages]
 
         info(event, "Sync flushing of #{messages.size} messages from the buffer")
-        debug(event, messages)
-      end
-
-      # @param event [Dry::Events::Event] event that happened with the details
-      def on_buffer_flushed_sync_error(event)
-        messages = event[:dispatched]
-        error = event[:error]
-
-        error(event, "Sync flushing of #{messages.size} failed due to: #{error}")
         debug(event, messages)
       end
 
@@ -103,10 +85,11 @@ module WaterDrop
       end
 
       # @param event [Dry::Events::Event] event that happened with the error details
-      def on_error_emitted(event)
+      def on_error_occurred(event)
         error = event[:error]
+        type = event[:type]
 
-        error(event, "Background thread error emitted: #{error}")
+        error(event, "Error occurred: #{error} - #{type}")
         debug(event, '')
       end
 

--- a/lib/water_drop/producer/buffer.rb
+++ b/lib/water_drop/producer/buffer.rb
@@ -103,8 +103,13 @@ module WaterDrop
           )
         end
       rescue *RESCUED_ERRORS => e
-        key = sync ? 'buffer.flushed_sync.error' : 'buffer.flush_async.error'
-        @monitor.instrument(key, producer_id: id, error: e, dispatched: dispatched)
+        @monitor.instrument(
+          'error.occurred',
+          error: e,
+          producer_id: id,
+          dispatched: dispatched,
+          type: sync ? 'buffer.flushed_sync.error' : 'buffer.flush_async.error'
+        )
 
         raise Errors::FlushFailureError.new(dispatched)
       end

--- a/lib/water_drop/version.rb
+++ b/lib/water_drop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.0.8'
+  VERSION = '2.1.0'
 end

--- a/lib/water_drop/version.rb
+++ b/lib/water_drop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.0.7'
+  VERSION = '2.0.8'
 end

--- a/spec/lib/water_drop/instrumentation/callbacks/error_spec.rb
+++ b/spec/lib/water_drop/instrumentation/callbacks/error_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe_current do
     let(:changed) { [] }
 
     before do
-      monitor.subscribe('error.emitted') do |event|
+      monitor.subscribe('error.occurred') do |event|
         changed << event[:error]
       end
 
       callback.call(client_name, error)
     end
 
-    context 'when emitted error refer different producer' do
+    context 'when occurred error refer different producer' do
       subject(:callback) { described_class.new(producer_id, 'other', monitor) }
 
       it 'expect not to emit them' do
@@ -27,27 +27,28 @@ RSpec.describe_current do
       end
     end
 
-    context 'when emitted error refer to expected producer' do
+    context 'when occurred error refer to expected producer' do
       it 'expects to emit them' do
         expect(changed).to eq([error])
       end
     end
   end
 
-  describe 'emitted event data format' do
+  describe 'occurred event data format' do
     let(:changed) { [] }
     let(:event) { changed.first }
 
     before do
-      monitor.subscribe('error.emitted') do |stat|
+      monitor.subscribe('error.occurred') do |stat|
         changed << stat
       end
 
       callback.call(client_name, error)
     end
 
-    it { expect(event.id).to eq('error.emitted') }
+    it { expect(event.id).to eq('error.occurred') }
     it { expect(event[:producer_id]).to eq(producer_id) }
     it { expect(event[:error]).to eq(error) }
+    it { expect(event[:type]).to eq('librdkafka.error') }
   end
 end

--- a/spec/lib/water_drop/instrumentation/stdout_listener_spec.rb
+++ b/spec/lib/water_drop/instrumentation/stdout_listener_spec.rb
@@ -103,18 +103,6 @@ RSpec.describe_current do
     it { expect(logged_data[1]).to include(messages[1].to_s) }
   end
 
-  describe '#on_buffer_flushed_async_error' do
-    before { listener.on_buffer_flushed_async_error(event) }
-
-    it { expect(logged_data[0]).to include(producer.id) }
-    it { expect(logged_data[0]).to include('ERROR') }
-    it { expect(logged_data[0]).to include('Async flushing of 2 failed') }
-    it { expect(logged_data[0]).to include(event[:error].to_s) }
-    it { expect(logged_data[1]).to include(producer.id) }
-    it { expect(logged_data[1]).to include('DEBUG') }
-    it { expect(logged_data[1]).to include(message.to_s) }
-  end
-
   describe '#on_buffer_flushed_sync' do
     before { listener.on_buffer_flushed_sync(event) }
 
@@ -127,18 +115,6 @@ RSpec.describe_current do
     it { expect(logged_data[1]).to include(messages[1].to_s) }
   end
 
-  describe '#on_buffer_flushed_sync_error' do
-    before { listener.on_buffer_flushed_sync_error(event) }
-
-    it { expect(logged_data[0]).to include(producer.id) }
-    it { expect(logged_data[0]).to include('ERROR') }
-    it { expect(logged_data[0]).to include('Sync flushing of 1 failed') }
-    it { expect(logged_data[0]).to include(event[:error].to_s) }
-    it { expect(logged_data[1]).to include(producer.id) }
-    it { expect(logged_data[1]).to include('DEBUG') }
-    it { expect(logged_data[1]).to include(message.to_s) }
-  end
-
   describe '#on_producer_closed' do
     before { listener.on_producer_closed(event) }
 
@@ -149,12 +125,15 @@ RSpec.describe_current do
     it { expect(logged_data[1]).to include('DEBUG') }
   end
 
-  describe '#on_error_emitted' do
-    before { listener.on_error_emitted(event) }
+  describe '#on_error_occurred' do
+    before do
+      details[:type] = 'error.type'
+      listener.on_error_occurred(event)
+    end
 
     it { expect(logged_data[0]).to include(producer.id) }
     it { expect(logged_data[0]).to include('ERROR') }
-    it { expect(logged_data[0]).to include('Background thread error emitted') }
+    it { expect(logged_data[0]).to include('Error occurred') }
     it { expect(logged_data[1]).to include(producer.id) }
     it { expect(logged_data[1]).to include('DEBUG') }
   end

--- a/spec/lib/water_drop/producer_spec.rb
+++ b/spec/lib/water_drop/producer_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe_current do
       let(:events) { [] }
 
       before do
-        producer.monitor.subscribe('error.emitted') do |event|
+        producer.monitor.subscribe('error.occurred') do |event|
           events << event
         end
 
@@ -252,7 +252,7 @@ RSpec.describe_current do
       end
 
       it 'expect to emit proper stats' do
-        expect(events.first.id).to eq('error.emitted')
+        expect(events.first.id).to eq('error.occurred')
         expect(events.first[:producer_id]).to eq(producer.id)
         expect(events.first[:error]).to be_a(Rdkafka::RdkafkaError)
       end
@@ -265,11 +265,11 @@ RSpec.describe_current do
       let(:events2) { [] }
 
       before do
-        producer1.monitor.subscribe('error.emitted') do |event|
+        producer1.monitor.subscribe('error.occurred') do |event|
           events1 << event
         end
 
-        producer2.monitor.subscribe('error.emitted') do |event|
+        producer2.monitor.subscribe('error.occurred') do |event|
           events2 << event
         end
 


### PR DESCRIPTION
This PR normalizes how we handle errors by emitting all of the errors into a single error notification channel / key `error.occurred`.

This change will allow us to:
- Will drastically simplify error handling as we won't have to track particular keys and support many of them. Instead we can just setup a listener and all errors will be reported.
- Propagate the same approach to Karafka and use a single error handle key across the framework

This will allow us to add new places where we report errors (if needed) and all the customers will be able to handle that out of the box without any code changes. It is much better for error notification than a granular engine.

In case someone needs a granular error detection, then can be done both based on the `type` key in the event as well as on the stacktrace (not recommended).

This is the last moment before the framework release where we can do this.

I also thought about using a wildcard subscription `*.error` or something similar on dry-monitor but it is not supported and also not as convenient as a single error handler endpoint.

Similar approach is used by many frameworks including Sidekiq (a single error handing entrypoint).