### PR TITLE
introduce a common contract base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WaterDrop changelog
 
+## 2.1.1 (Unreleased)
+- Introduce a common base for validation contracts
+
 ## 2.1.0 (2022-01-03)
 - Ruby 3.1 support
 - Change the error notification key from `error.emitted` to `error.occurred`.

--- a/lib/water_drop/config.rb
+++ b/lib/water_drop/config.rb
@@ -63,7 +63,8 @@ module WaterDrop
         yield(config)
 
         merge_kafka_defaults!(config)
-        validate!(config.to_h)
+
+        Contracts::Config.new.validate!(config.to_h, Errors::ConfigurationInvalidError)
 
         ::Rdkafka::Config.logger = config.logger
       end
@@ -81,17 +82,6 @@ module WaterDrop
 
         config.kafka[key] = value
       end
-    end
-
-    # Validates the configuration and if anything is wrong, will raise an exception
-    # @param config_hash [Hash] config hash with setup details
-    # @raise [WaterDrop::Errors::ConfigurationInvalidError] raised when something is wrong with
-    #   the configuration
-    def validate!(config_hash)
-      result = Contracts::Config.new.call(config_hash)
-      return true if result.success?
-
-      raise Errors::ConfigurationInvalidError, result.errors.to_h
     end
   end
 end

--- a/lib/water_drop/contracts/base.rb
+++ b/lib/water_drop/contracts/base.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module WaterDrop
+  module Contracts
+    # Base for all the contracts in WaterDrop
+    class Base < Dry::Validation::Contract
+      config.messages.load_paths << File.join(WaterDrop.gem_root, 'config', 'errors.yml')
+
+      # @param data [Hash] data for validation
+      # @param error_class [Class] error class that should be used when validation fails
+      # @return [true] true if all good or exception is raised
+      def validate!(data, error_class)
+        result = call(data)
+
+        return true if result.success?
+
+        raise error_class, result.errors.to_h
+      end
+    end
+  end
+end

--- a/lib/water_drop/contracts/base.rb
+++ b/lib/water_drop/contracts/base.rb
@@ -8,7 +8,6 @@ module WaterDrop
 
       # @param data [Hash] data for validation
       # @param error_class [Class] error class that should be used when validation fails
-      # @return [Boolean] true if all good or exception is raised
       def validate!(data, error_class)
         result = call(data)
 

--- a/lib/water_drop/contracts/base.rb
+++ b/lib/water_drop/contracts/base.rb
@@ -8,6 +8,9 @@ module WaterDrop
 
       # @param data [Hash] data for validation
       # @param error_class [Class] error class that should be used when validation fails
+      # @return [Boolean] true
+      # @raise [StandardError] any error provided in the error_class that inherits from the
+      #   standard error
       def validate!(data, error_class)
         result = call(data)
 

--- a/lib/water_drop/contracts/base.rb
+++ b/lib/water_drop/contracts/base.rb
@@ -8,7 +8,7 @@ module WaterDrop
 
       # @param data [Hash] data for validation
       # @param error_class [Class] error class that should be used when validation fails
-      # @return [true] true if all good or exception is raised
+      # @return [Boolean] true if all good or exception is raised
       def validate!(data, error_class)
         result = call(data)
 

--- a/lib/water_drop/contracts/config.rb
+++ b/lib/water_drop/contracts/config.rb
@@ -5,7 +5,7 @@ module WaterDrop
     # Contract with validation rules for WaterDrop configuration details
     class Config < Base
       # Ensure valid format of each seed broker so that rdkafka doesn't fail silently
-      SEED_BROKER_FORMAT_REGEXP = %r{\A([^:/,]+:[0-9]+)(,[^:/,]+:[0-9]+)*\z}.freeze
+      SEED_BROKER_FORMAT_REGEXP = %r{\A([^:/,]+:[0-9]+)(,[^:/,]+:[0-9]+)*\z}
 
       private_constant :SEED_BROKER_FORMAT_REGEXP
 

--- a/lib/water_drop/contracts/config.rb
+++ b/lib/water_drop/contracts/config.rb
@@ -3,7 +3,7 @@
 module WaterDrop
   module Contracts
     # Contract with validation rules for WaterDrop configuration details
-    class Config < Dry::Validation::Contract
+    class Config < Base
       # Ensure valid format of each seed broker so that rdkafka doesn't fail silently
       SEED_BROKER_FORMAT_REGEXP = %r{\A([^:/,]+:[0-9]+)(,[^:/,]+:[0-9]+)*\z}.freeze
 

--- a/lib/water_drop/contracts/message.rb
+++ b/lib/water_drop/contracts/message.rb
@@ -4,7 +4,7 @@ module WaterDrop
   module Contracts
     # Contract with validation rules for validating that all the message options that
     # we provide to producer ale valid and usable
-    class Message < Dry::Validation::Contract
+    class Message < Base
       # Regex to check that topic has a valid format
       TOPIC_REGEXP = /\A(\w|-|\.)+\z/.freeze
 
@@ -12,8 +12,6 @@ module WaterDrop
       STRING_ASSERTION = ->(value) { value.is_a?(String) }.to_proc
 
       private_constant :TOPIC_REGEXP, :STRING_ASSERTION
-
-      config.messages.load_paths << File.join(WaterDrop.gem_root, 'config', 'errors.yml')
 
       option :max_payload_size
 

--- a/lib/water_drop/contracts/message.rb
+++ b/lib/water_drop/contracts/message.rb
@@ -6,7 +6,7 @@ module WaterDrop
     # we provide to producer ale valid and usable
     class Message < Base
       # Regex to check that topic has a valid format
-      TOPIC_REGEXP = /\A(\w|-|\.)+\z/.freeze
+      TOPIC_REGEXP = /\A(\w|-|\.)+\z/
 
       # Checks, that the given value is a string
       STRING_ASSERTION = ->(value) { value.is_a?(String) }.to_proc

--- a/lib/water_drop/producer.rb
+++ b/lib/water_drop/producer.rb
@@ -150,13 +150,7 @@ module WaterDrop
     # @param message [Hash] message we want to send
     # @raise [Karafka::Errors::MessageInvalidError]
     def validate_message!(message)
-      result = @contract.call(message)
-      return if result.success?
-
-      raise Errors::MessageInvalidError, [
-        result.errors.to_h,
-        message
-      ]
+      @contract.validate!(message, Errors::MessageInvalidError)
     end
   end
 end

--- a/spec/lib/water_drop/contracts/base_spec.rb
+++ b/spec/lib/water_drop/contracts/base_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:validator_class) do
+    Class.new(described_class) do
+      params do
+        required(:id).filled(:str?)
+      end
+    end
+  end
+
+  describe '#validate!' do
+    subject(:validation) { validator_class.new.validate!(data, ArgumentError) }
+
+    context 'when data is valid' do
+      let(:data) { { id: '1' } }
+
+      it { expect { validation }.not_to raise_error }
+    end
+
+    context 'when data is not valid' do
+      let(:data) { { id: 1 } }
+
+      it { expect { validation }.to raise_error(ArgumentError) }
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a common base for contracts to align with incoming Karafka changes and a `#validate!` method as we always use validation in a raise-immediately way. No external APIs are impacted.