### PR TITLE
ensure kafka keys are symbolized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Align the directory namespace convention with gem name (waterdrop => WaterDrop)
 - Introduce a common base for validation contracts
 - Drop CI support for ruby 2.6
+- Require all `kafka` settings to have symbol keys (compatibility with Karafka 2.0 and rdkafka)
 
 ## 2.1.0 (2022-01-03)
 - Ruby 3.1 support

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ producer.setup do |config|
   config.kafka = {
     'bootstrap.servers': 'localhost:9092',
     # Accumulate messages for at most 10 seconds
-    'queue.buffering.max.ms' => 10_000
+    'queue.buffering.max.ms': 10_000
   }
 end
 

--- a/config/errors.yml
+++ b/config/errors.yml
@@ -4,3 +4,4 @@ en:
       invalid_key_type: all keys need to be of type String
       invalid_value_type: all values need to be of type String
       max_payload_size: is more than `max_payload_size` config value
+      kafka_key_must_be_a_symbol: All keys under the kafka settings scope need to be symbols

--- a/lib/waterdrop/config.rb
+++ b/lib/waterdrop/config.rb
@@ -9,7 +9,7 @@ module WaterDrop
 
     # Defaults for kafka settings, that will be overwritten only if not present already
     KAFKA_DEFAULTS = {
-      'client.id' => 'waterdrop'
+      'client.id': 'waterdrop'
     }.freeze
 
     private_constant :KAFKA_DEFAULTS

--- a/spec/lib/waterdrop/config_spec.rb
+++ b/spec/lib/waterdrop/config_spec.rb
@@ -6,20 +6,18 @@ RSpec.describe_current do
   describe '#setup' do
     context 'when configuration has errors' do
       let(:error_class) { ::WaterDrop::Errors::ConfigurationInvalidError }
-      let(:error_message) { { kafka: { 'bootstrap.servers': ['is missing'] } }.to_s }
-      let(:setup) { described_class.new.setup {} }
+      let(:setup) { described_class.new.setup { |config| config.kafka = { 'a' => true } } }
 
       it 'raise ConfigurationInvalidError exception' do
         expect { setup }.to raise_error do |error|
           expect(error).to be_a(error_class)
-          expect(error.message).to eq(error_message)
         end
       end
     end
 
     context 'when configuration is valid' do
       let(:kafka_config) do
-        { 'bootstrap.servers' => 'localhost:9092', rand => rand }
+        { 'bootstrap.servers': 'localhost:9092', rand.to_s.to_sym => rand }
       end
 
       it 'not raise ConfigurationInvalidError exception' do

--- a/spec/lib/waterdrop/contracts/config_spec.rb
+++ b/spec/lib/waterdrop/contracts/config_spec.rb
@@ -93,73 +93,10 @@ RSpec.describe_current do
   end
 
   context 'when kafka hash is present' do
-    let(:invalid_format) { 'is in invalid format' }
+    context 'when there is a non-symbol key setting' do
+      before { config[:kafka] = { 'not_a_symbol' => true } }
 
-    context 'when validating bootstrap.servers scope' do
-      before { config[:kafka] = { 'bootstrap.servers': bootstrap_servers } }
-
-      context 'when nil' do
-        let(:bootstrap_servers) { nil }
-
-        it { expect(contract_result).not_to be_success }
-        it { expect(contract_errors[:kafka][:'bootstrap.servers']).to eq ['must be filled'] }
-      end
-
-      context 'when an empty string' do
-        let(:bootstrap_servers) { '' }
-
-        it { expect(contract_result).not_to be_success }
-        it { expect(contract_errors[:kafka][:'bootstrap.servers']).to eq ['must be filled'] }
-      end
-
-      context 'when single seed broker with a non URI' do
-        let(:bootstrap_servers) { 1234 }
-
-        it { expect(contract_result).not_to be_success }
-        it { expect(contract_errors[:kafka][:'bootstrap.servers']).to eq(['must be a string']) }
-      end
-
-      context 'when single seed broker with explicit URI scheme' do
-        let(:bootstrap_servers) { 'kafka://127.0.0.1:9092' }
-
-        it { expect(contract_result).not_to be_success }
-        it { expect(contract_errors[:kafka][:'bootstrap.servers']).to eq [invalid_format] }
-      end
-
-      context 'when single seed broker without a port' do
-        let(:bootstrap_servers) { '127.0.0.1' }
-
-        it { expect(contract_result).not_to be_success }
-        it { expect(contract_errors[:kafka][:'bootstrap.servers']).to eq [invalid_format] }
-      end
-
-      context 'when a valid single seed broker' do
-        let(:bootstrap_servers) { '127.0.0.1:9092' }
-
-        it { expect(contract_result).to be_success }
-        it { expect(contract_errors).to be_empty }
-      end
-
-      context 'when multiple seed brokers with at one of them with explicit URI scheme' do
-        let(:bootstrap_servers) { '127.0.0.1:9092,kafka://127.0.0.1:9093' }
-
-        it { expect(contract_result).not_to be_success }
-        it { expect(contract_errors[:kafka][:'bootstrap.servers']).to eq [invalid_format] }
-      end
-
-      context 'when multiple seed brokers with at least one of them missing a port' do
-        let(:bootstrap_servers) { '127.0.0.1,kafka:9092' }
-
-        it { expect(contract_result).not_to be_success }
-        it { expect(contract_errors[:kafka][:'bootstrap.servers']).to eq [invalid_format] }
-      end
-
-      context 'when seed brokers separated by a comma, without explicit URI scheme, with port' do
-        let(:bootstrap_servers) { '127.0.0.1:9093,kafka:9092' }
-
-        it { expect(contract_result).to be_success }
-        it { expect(contract_errors).to be_empty }
-      end
+      it { expect(contract_result).not_to be_success }
     end
   end
 

--- a/spec/lib/waterdrop/instrumentation/vendors/datadog/listener_spec.rb
+++ b/spec/lib/waterdrop/instrumentation/vendors/datadog/listener_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe_current do
     let(:producer) do
       producer = create(
         :producer,
-        kafka: { 'bootstrap.servers' => 'localhost:9093', 'statistics.interval.ms' => 100 }
+        kafka: { 'bootstrap.servers': 'localhost:9093', 'statistics.interval.ms': 100 }
       )
       producer.monitor.subscribe listener
       producer

--- a/spec/lib/waterdrop/producer/builder_spec.rb
+++ b/spec/lib/waterdrop/producer/builder_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe_current do
 
     producer_config.setup do |config|
       config.deliver = should_deliver
-      config.kafka = { 'bootstrap.servers' => 'localhost:9092' }
+      config.kafka = { 'bootstrap.servers': 'localhost:9092' }
     end
 
     producer_config.config

--- a/spec/lib/waterdrop/producer_spec.rb
+++ b/spec/lib/waterdrop/producer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe_current do
       subject(:producer) do
         described_class.new do |config|
           config.deliver = false
-          config.kafka = { 'bootstrap.servers' => 'localhost:9092' }
+          config.kafka = { 'bootstrap.servers': 'localhost:9092' }
         end
       end
 
@@ -38,7 +38,7 @@ RSpec.describe_current do
       let(:setup) do
         lambda { |config|
           config.deliver = false
-          config.kafka = { 'bootstrap.servers' => 'localhost:9092' }
+          config.kafka = { 'bootstrap.servers': 'localhost:9092' }
         }
       end
 
@@ -235,7 +235,7 @@ RSpec.describe_current do
     let(:message) { build(:valid_message) }
 
     context 'when error occurs' do
-      subject(:producer) { build(:producer, kafka: { 'bootstrap.servers' => 'localhost:9090' }) }
+      subject(:producer) { build(:producer, kafka: { 'bootstrap.servers': 'localhost:9090' }) }
 
       let(:events) { [] }
 
@@ -259,8 +259,8 @@ RSpec.describe_current do
     end
 
     context 'when we have more producers' do
-      let(:producer1) { build(:producer, kafka: { 'bootstrap.servers' => 'localhost:9090' }) }
-      let(:producer2) { build(:producer, kafka: { 'bootstrap.servers' => 'localhost:9090' }) }
+      let(:producer1) { build(:producer, kafka: { 'bootstrap.servers': 'localhost:9090' }) }
+      let(:producer2) { build(:producer, kafka: { 'bootstrap.servers': 'localhost:9090' }) }
       let(:events1) { [] }
       let(:events2) { [] }
 

--- a/spec/support/factories/producer.rb
+++ b/spec/support/factories/producer.rb
@@ -9,10 +9,10 @@ FactoryBot.define do
     max_wait_timeout { 30 }
     kafka do
       {
-        'bootstrap.servers' => 'localhost:9092',
+        'bootstrap.servers': 'localhost:9092',
         # We emit statistics as it is a great way to check they actually always work
-        'statistics.interval.ms' => 100,
-        'request.required.acks' => 1
+        'statistics.interval.ms': 100,
+        'request.required.acks': 1
       }
     end
 


### PR DESCRIPTION
This PR ensures, that when defining Kafka settings, all are symbols. That way there won't a case where there is an accidental conflict or mistake.