### PR TITLE
v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # WaterDrop changelog
 
-## 2.2.0 (Unreleased)
+## 2.2.0 (2022-02-18)
 - Add Datadog listener for metrics + errors publishing
 - Add Datadog example dashboard template
 - Update Readme to show Dd instrumentation usage

--- a/waterdrop.gemspec
+++ b/waterdrop.gemspec
@@ -33,5 +33,9 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
-  spec.metadata      = { 'source_code_uri' => 'https://github.com/karafka/waterdrop' }
+
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/karafka/waterdrop',
+    'rubygems_mfa_required' => 'true'
+  }
 end


### PR DESCRIPTION
## 2.2.0 (2022-02-18)
- Add Datadog listener for metrics + errors publishing
- Add Datadog example dashboard template
- Update Readme to show Dd instrumentation usage
- Align the directory namespace convention with gem name (waterdrop => WaterDrop)
- Introduce a common base for validation contracts
- Drop CI support for ruby 2.6
- Require all `kafka` settings to have symbol keys (compatibility with Karafka 2.0 and rdkafka)