### PR TITLE
Support changes in rdkafka 0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WaterDrop changelog
 
+## Unreleased
+- Support for librdkafka 0.13
+
 ## 2.4.2 (2022-09-29)
 - Allow sending tombstone messages (#267)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.1)
 
 PLATFORMS
   arm64-darwin

--- a/lib/waterdrop/patches/rdkafka/producer.rb
+++ b/lib/waterdrop/patches/rdkafka/producer.rb
@@ -8,14 +8,22 @@ module WaterDrop
       # Rdkafka::Producer patches
       module Producer
         # Adds a method that allows us to get the native kafka producer name
+        #
+        # In between rdkafka versions, there are internal changes that force us to add some extra
+        # magic to support all the versions.
+        #
         # @return [String] producer instance name
         def name
           unless @_native
             version = ::Gem::Version.new(::Rdkafka::VERSION)
-            change = ::Gem::Version.new('0.12.0')
-            # 0.12.0 changed how the native producer client reference works.
-            # This code supports both older and newer versions of rdkafka
-            @_native = version >= change ? @client.native : @native_kafka
+
+            if version < ::Gem::Version.new('0.12.0')
+              @native = @native_kafka
+            elsif version < ::Gem::Version.new('0.13.0.beta.1')
+              @_native = @client.native
+            else
+              @_native = @native_kafka.inner
+            end
           end
 
           ::Rdkafka::Bindings.rd_kafka_name(@_native)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ if coverage
     add_filter '/.bundle/'
     add_filter '/doc/'
     add_filter '/config/'
+    add_filter '/lib/waterdrop/patches/'
 
     merge_timeout 600
     minimum_coverage 100


### PR DESCRIPTION
This PR adds changes needed to support rdkafka 0.13.beta1 and higher while remaining compatibility with previous versions.