### PR TITLE
retry metadata requests upon timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WaterDrop changelog
 
+## Unreleased
+- Add temporary patch on top of `rdkafka-ruby` to mitigate metadata fetch timeout failures.
+
 ## 2.4.3 (2022-12-07)
 - Support for librdkafka 0.13
 - Update Github Actions

--- a/lib/waterdrop/patches/rdkafka/metadata.rb
+++ b/lib/waterdrop/patches/rdkafka/metadata.rb
@@ -24,7 +24,7 @@ module WaterDrop
           backoff_factor = 2**attempt
           timeout = backoff_factor * 0.1
 
-          sleep(attempt)
+          sleep(timeout)
 
           retry
         end

--- a/lib/waterdrop/patches/rdkafka/metadata.rb
+++ b/lib/waterdrop/patches/rdkafka/metadata.rb
@@ -18,14 +18,15 @@ module WaterDrop
 
           super(*args)
         rescue Rdkafka::RdkafkaError => e
+          raise unless e.code == :timed_out
+          raise if attempt > 10
+
           backoff_factor = 2 ** attempt
           timeout = backoff_factor * 0.1
 
           sleep(attempt)
 
-          raise if attempt > 10
-          retry if e.code == :timed_out
-          raise(e)
+          retry
         end
       end
     end

--- a/lib/waterdrop/patches/rdkafka/metadata.rb
+++ b/lib/waterdrop/patches/rdkafka/metadata.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module WaterDrop
+  # Patches to external components
+  module Patches
+    # Rdkafka related patches
+    module Rdkafka
+      # Rdkafka::Metadata patches
+      module Metadata
+        # We overwrite this method because there were reports of metadata operation timing out
+        # when Kafka was under stress. While the messages dispatch will be retried, this was not
+        # and was causing problems.
+        #
+        # @param args [Array<Object>] all the metadata original arguments
+        def initialize(*args)
+          attempt ||= 0
+          attempt += 1
+
+          super(*args)
+        rescue Rdkafka::RdkafkaError => e
+          backoff_factor = 2 ** attempt
+          timeout = backoff_factor * 0.1
+
+          sleep(attempt)
+
+          raise if attempt > 10
+          retry if e.code == :timed_out
+          raise(e)
+        end
+      end
+    end
+  end
+end
+
+::Rdkafka::Metadata.prepend ::WaterDrop::Patches::Rdkafka::Metadata

--- a/lib/waterdrop/patches/rdkafka/metadata.rb
+++ b/lib/waterdrop/patches/rdkafka/metadata.rb
@@ -21,7 +21,7 @@ module WaterDrop
           raise unless e.code == :timed_out
           raise if attempt > 10
 
-          backoff_factor = 2 ** attempt
+          backoff_factor = 2**attempt
           timeout = backoff_factor * 0.1
 
           sleep(attempt)


### PR DESCRIPTION
There is a case where the metadata request times out. We need to implement a cache on top but this will mitigate the problem occurring in rdkafka itself.
