### PR TITLE
Introduce partition count cache and improve retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # WaterDrop changelog
 
+## 2.4.5 (Unreleased)
+- Fix invalid error scope visibility.
+- Cache partition count to improve messages production and lower stress on Kafka when `partition_key` is on.
+
 ## 2.4.4 (2022-12-09)
 - Add temporary patch on top of `rdkafka-ruby` to mitigate metadata fetch timeout failures.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.4.4)
+    waterdrop (2.4.5)
       karafka-core (>= 2.0.6, < 3.0.0)
       zeitwerk (~> 2.3)
 

--- a/lib/waterdrop/patches/rdkafka/metadata.rb
+++ b/lib/waterdrop/patches/rdkafka/metadata.rb
@@ -18,7 +18,7 @@ module WaterDrop
           attempt += 1
 
           super(*args)
-        rescue Rdkafka::RdkafkaError => e
+        rescue ::Rdkafka::RdkafkaError => e
           raise unless e.code == :timed_out
           raise if attempt > 10
 

--- a/lib/waterdrop/patches/rdkafka/producer.rb
+++ b/lib/waterdrop/patches/rdkafka/producer.rb
@@ -7,6 +7,22 @@ module WaterDrop
     module Rdkafka
       # Rdkafka::Producer patches
       module Producer
+        # Cache partitions count for 30 seconds
+        PARTITIONS_COUNT_TTL = 30_000
+
+        private_constant :PARTITIONS_COUNT_TTL
+
+        def initialize(*args)
+          super
+
+          @partitions_count_cache = Concurrent::Hash.new do |cache, topic|
+            cache[topic] = [
+              now,
+              ::Rdkafka::Metadata.new(inner_kafka, topic).topics&.first[:partition_count]
+            ]
+          end
+        end
+
         # Adds a method that allows us to get the native kafka producer name
         #
         # In between rdkafka versions, there are internal changes that force us to add some extra
@@ -14,23 +30,48 @@ module WaterDrop
         #
         # @return [String] producer instance name
         def name
-          unless @_native
+          @_name ||= ::Rdkafka::Bindings.rd_kafka_name(inner_kafka)
+        end
+
+        # This patch makes sure we cache the partition count for a given topic for given time
+        # This prevents us in case someone uses `partition_key` from querying for the count with
+        # each message. Instead we query once every 30 seconds at most
+        #
+        # @return [Integer] partition count for a given topic
+        def partition_count(topic)
+          closed_producer_check(__method__)
+
+          @partitions_count_cache.delete_if do |topic, cached|
+            now - cached.first > PARTITIONS_COUNT_TTL
+          end
+
+          @partitions_count_cache[topic].last
+        end
+
+        # @return [FFI::Pointer] pointer to the raw librdkafka
+        def inner_kafka
+          unless @_inner_kafka
             version = ::Gem::Version.new(::Rdkafka::VERSION)
 
             if version < ::Gem::Version.new('0.12.0')
-              @native = @native_kafka
+              @_inner_kafka = @native_kafka
             elsif version < ::Gem::Version.new('0.13.0.beta.1')
-              @_native = @client.native
+              @_inner_kafka = @client.native
             else
-              @_native = @native_kafka.inner
+              @_inner_kafka = @native_kafka.inner
             end
           end
 
-          ::Rdkafka::Bindings.rd_kafka_name(@_native)
+          @_inner_kafka
+        end
+
+        # @return [Float] current clock time
+        def now
+          ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) * 1_000
         end
       end
     end
   end
 end
 
-::Rdkafka::Producer.include ::WaterDrop::Patches::Rdkafka::Producer
+::Rdkafka::Producer.prepend ::WaterDrop::Patches::Rdkafka::Producer

--- a/lib/waterdrop/patches/rdkafka/producer.rb
+++ b/lib/waterdrop/patches/rdkafka/producer.rb
@@ -12,10 +12,11 @@ module WaterDrop
 
         private_constant :PARTITIONS_COUNT_TTL
 
+        # @param args [Object] arguments accepted by the original rdkafka producer
         def initialize(*args)
           super
 
-          @partitions_count_cache = Concurrent::Hash.new do |cache, topic|
+          @_partitions_count_cache = Concurrent::Hash.new do |cache, topic|
             cache[topic] = [
               now,
               ::Rdkafka::Metadata.new(inner_kafka, topic).topics&.first[:partition_count]
@@ -41,11 +42,11 @@ module WaterDrop
         def partition_count(topic)
           closed_producer_check(__method__)
 
-          @partitions_count_cache.delete_if do |topic, cached|
+          @_partitions_count_cache.delete_if do |topic, cached|
             now - cached.first > PARTITIONS_COUNT_TTL
           end
 
-          @partitions_count_cache[topic].last
+          @_partitions_count_cache[topic].last
         end
 
         # @return [FFI::Pointer] pointer to the raw librdkafka

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.4.4'
+  VERSION = '2.4.5'
 end

--- a/spec/lib/waterdrop/patches/rdkafka/metadata_spec.rb
+++ b/spec/lib/waterdrop/patches/rdkafka/metadata_spec.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:partition_count) do
+  subject(:partition_count) { producer.client.partition_count('example_topic') }
+
+  let(:producer) do
     WaterDrop::Producer.new do |config|
       config.deliver = true
       config.kafka = { 'bootstrap.servers': '127.0.0.1:9092' }
-    end.client.partition_count('topic')
+    end
   end
+
+  after { producer.close }
 
   describe 'metadata initialization recovery' do
     context 'when all good' do

--- a/spec/lib/waterdrop/patches/rdkafka/metadata_spec.rb
+++ b/spec/lib/waterdrop/patches/rdkafka/metadata_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:partition_count) do
+    WaterDrop::Producer.new do |config|
+      config.deliver = true
+      config.kafka = { 'bootstrap.servers': '127.0.0.1:9092' }
+    end.client.partition_count('topic')
+  end
+
+  describe 'metadata initialization recovery' do
+    context 'when all good' do
+      it { expect(partition_count).to eq(1) }
+    end
+
+    context 'when we fail for the first time with handled error' do
+      before do
+        raised = false
+
+        allow(Rdkafka::Bindings).to receive(:rd_kafka_metadata).and_wrap_original do |m, *args|
+          if raised
+            m.call(*args)
+          else
+            raised = true
+            -185
+          end
+        end
+      end
+
+      it { expect(partition_count).to eq(1) }
+    end
+  end
+end

--- a/spec/lib/waterdrop/patches/rdkafka/producer_spec.rb
+++ b/spec/lib/waterdrop/patches/rdkafka/producer_spec.rb
@@ -1,24 +1,28 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:client) do
+  subject(:client) { producer.client }
+
+  let(:producer) do
     WaterDrop::Producer.new do |config|
       config.deliver = true
       config.kafka = { 'bootstrap.servers': '127.0.0.1:9092' }
-    end.client
+    end
   end
 
+  after { producer.close }
+
   describe '#partition_count' do
-    it { expect(client.partition_count('topic')).to eq(1) }
+    it { expect(client.partition_count('example_topic')).to eq(1) }
 
     context 'when the partition count value is already cached' do
       before do
-        client.partition_count('topic')
+        client.partition_count('example_topic')
         allow(::Rdkafka::Metadata).to receive(:new).and_call_original
       end
 
       it 'expect not to query it again' do
-        client.partition_count('topic')
+        client.partition_count('example_topic')
         expect(::Rdkafka::Metadata).not_to have_received(:new)
       end
     end
@@ -26,12 +30,12 @@ RSpec.describe_current do
     context 'when the partition count value was cached but time expired' do
       before do
         allow(::Process).to receive(:clock_gettime).and_return(0, 30.001)
-        client.partition_count('topic')
+        client.partition_count('example_topic')
         allow(::Rdkafka::Metadata).to receive(:new).and_call_original
       end
 
       it 'expect not to query it again' do
-        client.partition_count('topic')
+        client.partition_count('example_topic')
         expect(::Rdkafka::Metadata).to have_received(:new)
       end
     end
@@ -39,12 +43,12 @@ RSpec.describe_current do
     context 'when the partition count value was cached and time did not expire' do
       before do
         allow(::Process).to receive(:clock_gettime).and_return(0, 29.001)
-        client.partition_count('topic')
+        client.partition_count('example_topic')
         allow(::Rdkafka::Metadata).to receive(:new).and_call_original
       end
 
       it 'expect not to query it again' do
-        client.partition_count('topic')
+        client.partition_count('example_topic')
         expect(::Rdkafka::Metadata).not_to have_received(:new)
       end
     end

--- a/spec/lib/waterdrop/patches/rdkafka/producer_spec.rb
+++ b/spec/lib/waterdrop/patches/rdkafka/producer_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:client) do
+    WaterDrop::Producer.new do |config|
+      config.deliver = true
+      config.kafka = { 'bootstrap.servers': '127.0.0.1:9092' }
+    end.client
+  end
+
+  describe '#partition_count' do
+    it { expect(client.partition_count('topic')).to eq(1) }
+
+    context 'when the partition count value is already cached' do
+      before do
+        client.partition_count('topic')
+        allow(::Rdkafka::Metadata).to receive(:new).and_call_original
+      end
+
+      it 'expect not to query it again' do
+        client.partition_count('topic')
+        expect(::Rdkafka::Metadata).not_to have_received(:new)
+      end
+    end
+
+    context 'when the partition count value was cached but time expired' do
+      before do
+        allow(::Process).to receive(:clock_gettime).and_return(0, 30.001)
+        client.partition_count('topic')
+        allow(::Rdkafka::Metadata).to receive(:new).and_call_original
+      end
+
+      it 'expect not to query it again' do
+        client.partition_count('topic')
+        expect(::Rdkafka::Metadata).to have_received(:new)
+      end
+    end
+
+    context 'when the partition count value was cached and time did not expire' do
+      before do
+        allow(::Process).to receive(:clock_gettime).and_return(0, 29.001)
+        client.partition_count('topic')
+        allow(::Rdkafka::Metadata).to receive(:new).and_call_original
+      end
+
+      it 'expect not to query it again' do
+        client.partition_count('topic')
+        expect(::Rdkafka::Metadata).not_to have_received(:new)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR:

- fixes the error catching visibility scope that was broken
- introduces a 30 second TTL cache on partition count so upon `partition_key` usage, we do not have to query kafka over and over again.
