### PR TITLE
Publishing middleware support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # WaterDrop changelog
 
+## 2.4.7 (Unreleased)
+- Add support to customizable middlewares that can modify message hash prior to validation and dispatch.
+- Fix a case where upon not-available leader, metadata request would not be retried
+
 ## 2.4.6 (2022-12-10)
 - Set `statistics.interval.ms` to 5 seconds by default, so the defaults cover all the instrumentation out of the box.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.4.6)
+    waterdrop (2.4.7)
       karafka-core (>= 2.0.6, < 3.0.0)
       zeitwerk (~> 2.3)
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It:
   * [Error notifications](#error-notifications)
   * [Datadog and StatsD integration](#datadog-and-statsd-integration)
   * [Forking and potential memory problems](#forking-and-potential-memory-problems)
+- [Middleware](#middleware)
 - [Note on contributions](#note-on-contributions)
 
 ## Installation
@@ -419,6 +420,38 @@ end
 If you work with forked processes, make sure you **don't** use the producer before the fork. You can easily configure the producer and then fork and use it.
 
 To tackle this [obstacle](https://github.com/appsignal/rdkafka-ruby/issues/15) related to rdkafka, WaterDrop adds finalizer to each of the producers to close the rdkafka client before the Ruby process is shutdown. Due to the [nature of the finalizers](https://www.mikeperham.com/2010/02/24/the-trouble-with-ruby-finalizers/), this implementation prevents producers from being GCed (except upon VM shutdown) and can cause memory leaks if you don't use persistent/long-lived producers in a long-running process or if you don't use the `#close` method of a producer when it is no longer needed. Creating a producer instance for each message is anyhow a rather bad idea, so we recommend not to.
+
+## Middleware
+
+WaterDrop supports injecting middleware similar to Rack.
+
+Middleware can be used to provide extra functionalities like auto-serialization of data or any other modifications of messages before their validation and dispatch.
+
+Each middleware accepts the message hash as input and expects a message hash as a result.
+
+There are two methods to register middlewares:
+
+- `#prepend` - registers middleware as the first in the order of execution
+- `#append` - registers middleware as the last in the order of execution
+
+Below you can find an example middleware that converts the incoming payload into a JSON string by running `#to_json` automatically:
+
+```ruby
+class AutoMapper
+  def call(message)
+    message[:payload] = message[:payload].to_s
+    message
+  end
+end
+
+# Register middleware
+producer.middleware.append(AutoMapper.new)
+
+# Dispatch without manual casting
+producer.produce_async(topic: 'users', payload: user)
+```
+
+**Note**: It is up to the end user to decide whether to modify the provided message or deep copy it and update the newly created one.
 
 ## Note on contributions
 

--- a/lib/waterdrop/config.rb
+++ b/lib/waterdrop/config.rb
@@ -57,6 +57,12 @@ module WaterDrop
     # rdkafka options
     # @see https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
     setting :kafka, default: {}
+    # Middleware chain that can be expanded with useful middleware steps
+    setting(
+      :middleware,
+      default: false,
+      constructor: ->(middleware) { middleware || WaterDrop::Middleware.new }
+    )
 
     # Configuration method
     # @yield Runs a block of code providing a config singleton instance to it

--- a/lib/waterdrop/instrumentation/logger_listener.rb
+++ b/lib/waterdrop/instrumentation/logger_listener.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module WaterDrop
+  # WaterDrop instrumentation related module
   module Instrumentation
     # Default listener that hooks up to our instrumentation and uses its events for logging
     # It can be removed/replaced or anything without any harm to the Waterdrop flow

--- a/lib/waterdrop/middleware.rb
+++ b/lib/waterdrop/middleware.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module WaterDrop
+  # Simple middleware layer for manipulating messages prior to their validation
+  class Middleware
+    def initialize
+      @mutex = Mutex.new
+      @steps = []
+    end
+
+    # Runs middleware on a single message prior to validation
+    #
+    # @param message [Hash] message hash
+    # @return [Hash] message hash. Either the same if transformed in place, or a copy if modified
+    #   into a new object.
+    # @note You need to decide yourself whether you don't use the message hash data anywhere else
+    #   and you want to save on memory by modifying it in place or do you want to do a deep copy
+    def run(message)
+      @steps.each do |step|
+        message = step.call(message)
+      end
+
+      message
+    end
+
+    # @param messages [Array<Hash>] messages on which we want to run middlewares
+    # @return [Array<Hash>] transformed messages
+    def run_many(messages)
+      messages.map do |message|
+        run(message)
+      end
+    end
+
+    # Register given middleware as the first one in the chain
+    # @param step [#call] step that needs to return the message
+    def prepend(step)
+      @mutex.synchronize do
+        @steps.prepend step
+      end
+    end
+
+    # Register given middleware as the last one in the chain
+    # @param step [#call] step that needs to return the message
+    def append(step)
+      @mutex.synchronize do
+        @steps.append step
+      end
+    end
+  end
+end

--- a/lib/waterdrop/patches/rdkafka/metadata.rb
+++ b/lib/waterdrop/patches/rdkafka/metadata.rb
@@ -7,6 +7,13 @@ module WaterDrop
     module Rdkafka
       # Rdkafka::Metadata patches
       module Metadata
+        RETRIED_ERRORS = %i[
+          timed_out
+          leader_not_available
+        ].freeze
+
+        private_constant :RETRIED_ERRORS
+
         # We overwrite this method because there were reports of metadata operation timing out
         # when Kafka was under stress. While the messages dispatch will be retried, metadata
         # fetch happens prior to that, effectively crashing the process. Metadata fetch was not
@@ -19,7 +26,7 @@ module WaterDrop
 
           super(*args)
         rescue ::Rdkafka::RdkafkaError => e
-          raise unless e.code == :timed_out
+          raise unless RETRIED_ERRORS.include?(e.code)
           raise if attempt > 10
 
           backoff_factor = 2**attempt

--- a/lib/waterdrop/patches/rdkafka/metadata.rb
+++ b/lib/waterdrop/patches/rdkafka/metadata.rb
@@ -7,6 +7,7 @@ module WaterDrop
     module Rdkafka
       # Rdkafka::Metadata patches
       module Metadata
+        # Errors upon which we retry the metadata fetch
         RETRIED_ERRORS = %i[
           timed_out
           leader_not_available

--- a/lib/waterdrop/producer.rb
+++ b/lib/waterdrop/producer.rb
@@ -3,9 +3,12 @@
 module WaterDrop
   # Main WaterDrop messages producer
   class Producer
+    extend Forwardable
     include Sync
     include Async
     include Buffer
+
+    def_delegators :config, :middleware
 
     # @return [String] uuid of the current producer
     attr_reader :id

--- a/lib/waterdrop/producer/async.rb
+++ b/lib/waterdrop/producer/async.rb
@@ -15,6 +15,8 @@ module WaterDrop
       #   message could not be sent to Kafka
       def produce_async(message)
         ensure_active!
+
+        message = middleware.run(message)
         validate_message!(message)
 
         @monitor.instrument(
@@ -36,6 +38,8 @@ module WaterDrop
       #   and the message could not be sent to Kafka
       def produce_many_async(messages)
         ensure_active!
+
+        messages = middleware.run_many(messages)
         messages.each { |message| validate_message!(message) }
 
         @monitor.instrument(

--- a/lib/waterdrop/producer/buffer.rb
+++ b/lib/waterdrop/producer/buffer.rb
@@ -19,6 +19,7 @@ module WaterDrop
       #   message could not be sent to Kafka
       def buffer(message)
         ensure_active!
+        message = middleware.run(message)
         validate_message!(message)
 
         @monitor.instrument(
@@ -37,6 +38,8 @@ module WaterDrop
       #   and the message could not be sent to Kafka
       def buffer_many(messages)
         ensure_active!
+
+        messages = middleware.run_many(messages)
         messages.each { |message| validate_message!(message) }
 
         @monitor.instrument(

--- a/lib/waterdrop/producer/sync.rb
+++ b/lib/waterdrop/producer/sync.rb
@@ -17,6 +17,8 @@ module WaterDrop
       #   message could not be sent to Kafka
       def produce_sync(message)
         ensure_active!
+
+        message = middleware.run(message)
         validate_message!(message)
 
         @monitor.instrument(
@@ -47,6 +49,8 @@ module WaterDrop
       #   and the message could not be sent to Kafka
       def produce_many_sync(messages)
         ensure_active!
+
+        messages = middleware.run_many(messages)
         messages.each { |message| validate_message!(message) }
 
         @monitor.instrument('messages.produced_sync', producer_id: id, messages: messages) do

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.4.6'
+  VERSION = '2.4.7'
 end

--- a/spec/lib/waterdrop/middleware_spec.rb
+++ b/spec/lib/waterdrop/middleware_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:middleware) { described_class.new }
+
+  let(:message) { build(:valid_message) }
+
+  context 'when no middlewares' do
+    it { expect { middleware.run(message) }.not_to change { message } }
+  end
+
+  context 'when morphing middleware' do
+    before do
+      middleware.prepend ->(msg) do
+        msg[:test] = 1
+        msg
+      end
+    end
+
+    it { expect { middleware.run(message) }.to change { message[:test] }.from(nil).to(1) }
+  end
+
+  context 'when morphing middlewares' do
+    before do
+      middleware.prepend ->(msg) do
+        msg[:test] = 1
+        msg
+      end
+
+      middleware.prepend ->(msg) do
+        msg[:test2] = 2
+        msg
+      end
+    end
+
+    it { expect { middleware.run(message) }.to change { message[:test] }.from(nil).to(1) }
+    it { expect { middleware.run(message) }.to change { message[:test2] }.from(nil).to(2) }
+  end
+
+  context 'when non-morphing middleware' do
+    before do
+      middleware.prepend ->(msg) do
+        msg = msg.dup
+        msg[:test] = 1
+        msg
+      end
+    end
+
+    it { expect { middleware.run(message) }.not_to change { message } }
+    it { expect(middleware.run(message)[:test]).to eq(1) }
+  end
+
+  context 'when non-morphing middlewares' do
+    before do
+      middleware.prepend ->(msg) do
+        msg = msg.dup
+
+        msg[:test] = 1
+        msg
+      end
+
+      middleware.prepend ->(msg) do
+        msg = msg.dup
+
+        msg[:test2] = 2
+        msg
+      end
+    end
+
+    it { expect { middleware.run(message) }.not_to change { message } }
+    it { expect(middleware.run(message)[:test]).to eq(1) }
+    it { expect(middleware.run(message)[:test2]).to eq(2) }
+  end
+
+  context 'when morphing middleware on many' do
+    before do
+      middleware.append ->(msg) do
+        msg[:test] = 1
+        msg
+      end
+    end
+
+    it { expect { middleware.run_many([message]) }.to change { message[:test] }.from(nil).to(1) }
+  end
+
+  context 'when morphing middlewares on many' do
+    before do
+      middleware.append ->(msg) do
+        msg[:test] = 1
+        msg
+      end
+
+      middleware.append ->(msg) do
+        msg[:test2] = 2
+        msg
+      end
+    end
+
+    it { expect { middleware.run_many([message]) }.to change { message[:test] }.from(nil).to(1) }
+    it { expect { middleware.run_many([message]) }.to change { message[:test2] }.from(nil).to(2) }
+  end
+
+  context 'when non-morphing middleware on many' do
+    before do
+      middleware.append ->(msg) do
+        msg = msg.dup
+        msg[:test] = 1
+        msg
+      end
+    end
+
+    it { expect { middleware.run_many([message]) }.not_to change { message } }
+    it { expect(middleware.run_many([message]).first[:test]).to eq(1) }
+  end
+end

--- a/spec/lib/waterdrop/middleware_spec.rb
+++ b/spec/lib/waterdrop/middleware_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe_current do
 
   context 'when morphing middleware' do
     before do
-      middleware.prepend lambda do |msg|
+      middleware.prepend -> (msg)
         msg[:test] = 1
         msg
       end
@@ -22,12 +22,12 @@ RSpec.describe_current do
 
   context 'when morphing middlewares' do
     before do
-      middleware.prepend lambda do |msg|
+      middleware.prepend -> (msg)
         msg[:test] = 1
         msg
       end
 
-      middleware.prepend lambda do |msg|
+      middleware.prepend -> (msg)
         msg[:test2] = 2
         msg
       end
@@ -39,7 +39,7 @@ RSpec.describe_current do
 
   context 'when non-morphing middleware' do
     before do
-      middleware.prepend lambda do |msg|
+      middleware.prepend -> (msg)
         msg = msg.dup
         msg[:test] = 1
         msg
@@ -52,14 +52,14 @@ RSpec.describe_current do
 
   context 'when non-morphing middlewares' do
     before do
-      middleware.prepend lambda do |msg|
+      middleware.prepend -> (msg)
         msg = msg.dup
 
         msg[:test] = 1
         msg
       end
 
-      middleware.prepend lambda do |msg|
+      middleware.prepend -> (msg)
         msg = msg.dup
 
         msg[:test2] = 2
@@ -74,7 +74,7 @@ RSpec.describe_current do
 
   context 'when morphing middleware on many' do
     before do
-      middleware.append lambda do |msg|
+      middleware.append -> (msg)
         msg[:test] = 1
         msg
       end
@@ -85,12 +85,12 @@ RSpec.describe_current do
 
   context 'when morphing middlewares on many' do
     before do
-      middleware.append lambda do |msg|
+      middleware.append -> (msg)
         msg[:test] = 1
         msg
       end
 
-      middleware.append lambda do |msg|
+      middleware.append -> (msg)
         msg[:test2] = 2
         msg
       end
@@ -102,7 +102,7 @@ RSpec.describe_current do
 
   context 'when non-morphing middleware on many' do
     before do
-      middleware.append lambda do |msg|
+      middleware.append -> (msg)
         msg = msg.dup
         msg[:test] = 1
         msg

--- a/spec/lib/waterdrop/middleware_spec.rb
+++ b/spec/lib/waterdrop/middleware_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe_current do
 
   context 'when morphing middlewares' do
     before do
-      mid = lambda do |msg|
+      mid1 = lambda do |msg|
         msg[:test] = 1
         msg
       end
 
-      mid = lambda do |msg|
+      mid2 = lambda do |msg|
         msg[:test2] = 2
         msg
       end

--- a/spec/lib/waterdrop/middleware_spec.rb
+++ b/spec/lib/waterdrop/middleware_spec.rb
@@ -11,35 +11,35 @@ RSpec.describe_current do
 
   context 'when morphing middleware' do
     before do
-      middleware.prepend ->(msg) do
+      middleware.prepend lambda do |msg|
         msg[:test] = 1
         msg
       end
     end
 
-    it { expect { middleware.run(message) }.to change { message[:test] }.from(nil).to(1) }
+    it { expect { middleware.run(message) }.to(change { message[:test] }.from(nil).to(1)) }
   end
 
   context 'when morphing middlewares' do
     before do
-      middleware.prepend ->(msg) do
+      middleware.prepend lambda do |msg|
         msg[:test] = 1
         msg
       end
 
-      middleware.prepend ->(msg) do
+      middleware.prepend lambda do |msg|
         msg[:test2] = 2
         msg
       end
     end
 
-    it { expect { middleware.run(message) }.to change { message[:test] }.from(nil).to(1) }
-    it { expect { middleware.run(message) }.to change { message[:test2] }.from(nil).to(2) }
+    it { expect { middleware.run(message) }.to(change { message[:test] }.from(nil).to(1)) }
+    it { expect { middleware.run(message) }.to(change { message[:test2] }.from(nil).to(2)) }
   end
 
   context 'when non-morphing middleware' do
     before do
-      middleware.prepend ->(msg) do
+      middleware.prepend lambda do |msg|
         msg = msg.dup
         msg[:test] = 1
         msg
@@ -52,14 +52,14 @@ RSpec.describe_current do
 
   context 'when non-morphing middlewares' do
     before do
-      middleware.prepend ->(msg) do
+      middleware.prepend lambda do |msg|
         msg = msg.dup
 
         msg[:test] = 1
         msg
       end
 
-      middleware.prepend ->(msg) do
+      middleware.prepend lambda do |msg|
         msg = msg.dup
 
         msg[:test2] = 2
@@ -74,35 +74,35 @@ RSpec.describe_current do
 
   context 'when morphing middleware on many' do
     before do
-      middleware.append ->(msg) do
+      middleware.append lambda do |msg|
         msg[:test] = 1
         msg
       end
     end
 
-    it { expect { middleware.run_many([message]) }.to change { message[:test] }.from(nil).to(1) }
+    it { expect { middleware.run_many([message]) }.to(change { message[:test] }.from(nil).to(1)) }
   end
 
   context 'when morphing middlewares on many' do
     before do
-      middleware.append ->(msg) do
+      middleware.append lambda do |msg|
         msg[:test] = 1
         msg
       end
 
-      middleware.append ->(msg) do
+      middleware.append lambda do |msg|
         msg[:test2] = 2
         msg
       end
     end
 
-    it { expect { middleware.run_many([message]) }.to change { message[:test] }.from(nil).to(1) }
-    it { expect { middleware.run_many([message]) }.to change { message[:test2] }.from(nil).to(2) }
+    it { expect { middleware.run_many([message]) }.to(change { message[:test] }.from(nil).to(1)) }
+    it { expect { middleware.run_many([message]) }.to(change { message[:test2] }.from(nil).to(2)) }
   end
 
   context 'when non-morphing middleware on many' do
     before do
-      middleware.append ->(msg) do
+      middleware.append lambda do |msg|
         msg = msg.dup
         msg[:test] = 1
         msg

--- a/spec/lib/waterdrop/middleware_spec.rb
+++ b/spec/lib/waterdrop/middleware_spec.rb
@@ -11,10 +11,12 @@ RSpec.describe_current do
 
   context 'when morphing middleware' do
     before do
-      middleware.prepend -> (msg)
+      mid1 = lambda do |msg|
         msg[:test] = 1
         msg
       end
+
+      middleware.prepend mid1
     end
 
     it { expect { middleware.run(message) }.to(change { message[:test] }.from(nil).to(1)) }
@@ -22,15 +24,18 @@ RSpec.describe_current do
 
   context 'when morphing middlewares' do
     before do
-      middleware.prepend -> (msg)
+      mid = lambda do |msg|
         msg[:test] = 1
         msg
       end
 
-      middleware.prepend -> (msg)
+      mid = lambda do |msg|
         msg[:test2] = 2
         msg
       end
+
+      middleware.prepend mid1
+      middleware.prepend mid2
     end
 
     it { expect { middleware.run(message) }.to(change { message[:test] }.from(nil).to(1)) }
@@ -39,11 +44,13 @@ RSpec.describe_current do
 
   context 'when non-morphing middleware' do
     before do
-      middleware.prepend -> (msg)
+      mid1 = lambda do |msg|
         msg = msg.dup
         msg[:test] = 1
         msg
       end
+
+      middleware.prepend mid1
     end
 
     it { expect { middleware.run(message) }.not_to(change { message }) }
@@ -52,19 +59,22 @@ RSpec.describe_current do
 
   context 'when non-morphing middlewares' do
     before do
-      middleware.prepend -> (msg)
+      mid1 = lambda do |msg|
         msg = msg.dup
 
         msg[:test] = 1
         msg
       end
 
-      middleware.prepend -> (msg)
+      mid2 = lambda do |msg|
         msg = msg.dup
 
         msg[:test2] = 2
         msg
       end
+
+      middleware.prepend mid1
+      middleware.prepend mid2
     end
 
     it { expect { middleware.run(message) }.not_to(change { message }) }
@@ -74,10 +84,12 @@ RSpec.describe_current do
 
   context 'when morphing middleware on many' do
     before do
-      middleware.append -> (msg)
+      mid1 = lambda do |msg|
         msg[:test] = 1
         msg
       end
+
+      middleware.append mid1
     end
 
     it { expect { middleware.run_many([message]) }.to(change { message[:test] }.from(nil).to(1)) }
@@ -85,15 +97,18 @@ RSpec.describe_current do
 
   context 'when morphing middlewares on many' do
     before do
-      middleware.append -> (msg)
+      mid1 = lambda do |msg|
         msg[:test] = 1
         msg
       end
 
-      middleware.append -> (msg)
+      mid2 = lambda do |msg|
         msg[:test2] = 2
         msg
       end
+
+      middleware.append mid1
+      middleware.append mid2
     end
 
     it { expect { middleware.run_many([message]) }.to(change { message[:test] }.from(nil).to(1)) }
@@ -102,11 +117,13 @@ RSpec.describe_current do
 
   context 'when non-morphing middleware on many' do
     before do
-      middleware.append -> (msg)
+      mid1 = lambda do |msg|
         msg = msg.dup
         msg[:test] = 1
         msg
       end
+
+      middleware.append mid1
     end
 
     it { expect { middleware.run_many([message]) }.not_to(change { message }) }

--- a/spec/lib/waterdrop/middleware_spec.rb
+++ b/spec/lib/waterdrop/middleware_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe_current do
   let(:message) { build(:valid_message) }
 
   context 'when no middlewares' do
-    it { expect { middleware.run(message) }.not_to change { message } }
+    it { expect { middleware.run(message) }.not_to(change { message }) }
   end
 
   context 'when morphing middleware' do
@@ -46,7 +46,7 @@ RSpec.describe_current do
       end
     end
 
-    it { expect { middleware.run(message) }.not_to change { message } }
+    it { expect { middleware.run(message) }.not_to(change { message }) }
     it { expect(middleware.run(message)[:test]).to eq(1) }
   end
 
@@ -67,7 +67,7 @@ RSpec.describe_current do
       end
     end
 
-    it { expect { middleware.run(message) }.not_to change { message } }
+    it { expect { middleware.run(message) }.not_to(change { message }) }
     it { expect(middleware.run(message)[:test]).to eq(1) }
     it { expect(middleware.run(message)[:test2]).to eq(2) }
   end
@@ -109,7 +109,7 @@ RSpec.describe_current do
       end
     end
 
-    it { expect { middleware.run_many([message]) }.not_to change { message } }
+    it { expect { middleware.run_many([message]) }.not_to(change { message }) }
     it { expect(middleware.run_many([message]).first[:test]).to eq(1) }
   end
 end

--- a/spec/lib/waterdrop/producer/async_spec.rb
+++ b/spec/lib/waterdrop/producer/async_spec.rb
@@ -25,6 +25,32 @@ RSpec.describe_current do
 
       it { expect(delivery).to be_a(Rdkafka::Producer::DeliveryHandle) }
     end
+
+    context 'when producing with good middleware' do
+      before do
+        producer.middleware.append ->(msg) do
+          msg[:partition_key] = '1'
+          msg
+        end
+      end
+
+      let(:message) { build(:valid_message, payload: nil) }
+
+      it { expect(delivery).to be_a(Rdkafka::Producer::DeliveryHandle) }
+    end
+
+    context 'when producing with corrupted middleware' do
+      before do
+        producer.middleware.append ->(msg) do
+          msg[:partition_key] = -1
+          msg
+        end
+      end
+
+      let(:message) { build(:valid_message, payload: nil) }
+
+      it { expect { delivery }.to raise_error(WaterDrop::Errors::MessageInvalidError) }
+    end
   end
 
   describe '#produce_many_async' do

--- a/spec/lib/waterdrop/producer/async_spec.rb
+++ b/spec/lib/waterdrop/producer/async_spec.rb
@@ -28,10 +28,12 @@ RSpec.describe_current do
 
     context 'when producing with good middleware' do
       before do
-        producer.middleware.append -> (msg)
+        mid = lambda do |msg|
           msg[:partition_key] = '1'
           msg
         end
+
+        producer.middleware.append mid
       end
 
       let(:message) { build(:valid_message, payload: nil) }
@@ -41,10 +43,12 @@ RSpec.describe_current do
 
     context 'when producing with corrupted middleware' do
       before do
-        producer.middleware.append -> (msg)
+        mid = lambda do |msg|
           msg[:partition_key] = -1
           msg
         end
+
+        producer.middleware.append mid
       end
 
       let(:message) { build(:valid_message, payload: nil) }

--- a/spec/lib/waterdrop/producer/async_spec.rb
+++ b/spec/lib/waterdrop/producer/async_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe_current do
 
     context 'when producing with good middleware' do
       before do
-        producer.middleware.append ->(msg) do
+        producer.middleware.append lambda do |msg|
           msg[:partition_key] = '1'
           msg
         end
@@ -41,7 +41,7 @@ RSpec.describe_current do
 
     context 'when producing with corrupted middleware' do
       before do
-        producer.middleware.append ->(msg) do
+        producer.middleware.append lambda do |msg|
           msg[:partition_key] = -1
           msg
         end

--- a/spec/lib/waterdrop/producer/async_spec.rb
+++ b/spec/lib/waterdrop/producer/async_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe_current do
 
     context 'when producing with good middleware' do
       before do
-        producer.middleware.append lambda do |msg|
+        producer.middleware.append -> (msg)
           msg[:partition_key] = '1'
           msg
         end
@@ -41,7 +41,7 @@ RSpec.describe_current do
 
     context 'when producing with corrupted middleware' do
       before do
-        producer.middleware.append lambda do |msg|
+        producer.middleware.append -> (msg)
           msg[:partition_key] = -1
           msg
         end


### PR DESCRIPTION
This PR:
- adds support for pre-validation and pre-dispatch middleware
- adds support for missing leader retry on metadata
