### PR TITLE
Use time from core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WaterDrop changelog
 
+## 2.4.8 (Unreleased)
+- Use monotonic time from Karafka core.
+
 ## 2.4.7 (2022-12-18)
 - Add support to customizable middlewares that can modify message hash prior to validation and dispatch.
 - Fix a case where upon not-available leader, metadata request would not be retried

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     waterdrop (2.4.7)
-      karafka-core (>= 2.0.7, < 3.0.0)
+      karafka-core (>= 2.0.8, < 3.0.0)
       zeitwerk (~> 2.3)
 
 GEM
@@ -22,7 +22,7 @@ GEM
     ffi (1.15.5)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    karafka-core (2.0.7)
+    karafka-core (2.0.8)
       concurrent-ruby (>= 1.1)
       rdkafka (>= 0.12)
     mini_portile2 (2.8.1)

--- a/waterdrop.gemspec
+++ b/waterdrop.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.license       = 'MIT'
 
-  spec.add_dependency 'karafka-core', '>= 2.0.7', '< 3.0.0'
+  spec.add_dependency 'karafka-core', '>= 2.0.8', '< 3.0.0'
   spec.add_dependency 'zeitwerk', '~> 2.3'
 
   spec.required_ruby_version = '>= 2.7'


### PR DESCRIPTION
This PR delegates the time methods to `Karafka::Core::Helpers::Time` to align with karafka and web.