### PR TITLE
rely on version lock from core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.4.9 (Unreleased)
 - Remove empty debug logging out of `LoggerListener`.
+- Do not lock Ruby version in Karafka in favour of `karafka-core`.
 
 ## 2.4.8 (2023-01-07)
 - Use monotonic time from Karafka core.

--- a/waterdrop.gemspec
+++ b/waterdrop.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'karafka-core', '>= 2.0.8', '< 3.0.0'
   spec.add_dependency 'zeitwerk', '~> 2.3'
 
-  spec.required_ruby_version = '>= 2.7'
-
   if $PROGRAM_NAME.end_with?('gem')
     spec.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')
   end


### PR DESCRIPTION
same as here: https://github.com/karafka/karafka/pull/1263