### PR TITLE
Include caller in the instrumentation calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WaterDrop changelog
 
+## 2.4.10 (Unreleased)
+- Include `caller` in the error instrumentation to align with Karafka.
+
 ## 2.4.9 (2023-01-11)
 - Remove empty debug logging out of `LoggerListener`.
 - Do not lock Ruby version in Karafka in favour of `karafka-core`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.4.9)
+    waterdrop (2.4.10)
       karafka-core (>= 2.0.9, < 3.0.0)
       zeitwerk (~> 2.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4)
+    activesupport (7.0.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     byebug (11.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     factory_bot (6.2.1)
@@ -41,7 +41,7 @@ GEM
     rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.2)
+    rspec-mocks (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -51,7 +51,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     zeitwerk (2.6.6)
 
@@ -66,4 +66,4 @@ DEPENDENCIES
   waterdrop!
 
 BUNDLED WITH
-   2.4.2
+   2.4.5

--- a/lib/waterdrop/instrumentation/callbacks/error.rb
+++ b/lib/waterdrop/instrumentation/callbacks/error.rb
@@ -25,6 +25,7 @@ module WaterDrop
 
           @monitor.instrument(
             'error.occurred',
+            caller: self,
             error: error,
             producer_id: @producer_id,
             type: 'librdkafka.error'

--- a/lib/waterdrop/producer/buffer.rb
+++ b/lib/waterdrop/producer/buffer.rb
@@ -110,6 +110,7 @@ module WaterDrop
       rescue *RESCUED_ERRORS => e
         @monitor.instrument(
           'error.occurred',
+          caller: self,
           error: e,
           producer_id: id,
           dispatched: dispatched,

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.4.9'
+  VERSION = '2.4.10'
 end


### PR DESCRIPTION
This PR adds the caller key to error instrumentation, so the API is aligned with Karafka.