### PR TITLE
Allow for notifications events list programmatic access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.4.11 (Unreleased)
 - Replace the local rspec locator with generalized core one.
+- Make `::WaterDrop::Instrumentation::Notifications::EVENTS` list public for anyone wanting to re-bind those into a different notification bus.
 
 ## 2.4.10 (2023-01-30)
 - Include `caller` in the error instrumentation to align with Karafka.

--- a/lib/waterdrop/instrumentation/notifications.rb
+++ b/lib/waterdrop/instrumentation/notifications.rb
@@ -26,8 +26,6 @@ module WaterDrop
         error.occurred
       ].freeze
 
-      private_constant :EVENTS
-
       # @return [WaterDrop::Instrumentation::Monitor] monitor instance for system instrumentation
       def initialize
         super


### PR DESCRIPTION
small change to allow ppl to rebind the events onto an alternative notifications bus