### PR TITLE
Pipe delivery errors coming from reports via notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WaterDrop changelog
 
+## 2.4.12 (Unreleased)
+- Pipe delivery errors that occurred not via the error callback using the `error.occurred` channel.
+
 ## 2.4.11 (2023-02-24)
 - Replace the local rspec locator with generalized core one.
 - Make `::WaterDrop::Instrumentation::Notifications::EVENTS` list public for anyone wanting to re-bind those into a different notification bus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove the `WaterDrop::Errors::FlushFailureError` in favour of correct error that occurred to unify the error handling.
 - Introduce `WaterDrop::Errors::ProduceError` and `WaterDrop::Errors::ProduceManyError` for any inline raised errors that occur. You can get the original error by using the `#cause`.
 - Do **not** flush when there is no data to flush in the internal buffer.
+- Include `#dispatched` messages handler in the `WaterDrop::Errors::ProduceManyError` error, to be able to understand which of the messages were delegated to `librdkafka` prior to the failure.
 
 ## 2.4.11 (2023-02-24)
 - Replace the local rspec locator with generalized core one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - [Improvement] Include `#dispatched` messages handler in the `WaterDrop::Errors::ProduceManyError` error, to be able to understand which of the messages were delegated to `librdkafka` prior to the failure.
 - [Maintenance] Remove the `WaterDrop::Errors::FlushFailureError` in favour of correct error that occurred to unify the error handling.
 - [Fix] Do **not** flush when there is no data to flush in the internal buffer.
-- [Fix] Wait on last dispatched message for super short-lived producers to make sure, that the message is actually dispatched by `librdkafka` or timeout.
+- [Fix] Wait on the final data flush for short-lived producers to make sure, that the message is actually dispatched by `librdkafka` or timeout.
 
 ## 2.4.11 (2023-02-24)
 - Replace the local rspec locator with generalized core one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 - [Fix] Do **not** flush when there is no data to flush in the internal buffer.
 - [Fix] Wait on the final data flush for short-lived producers to make sure, that the message is actually dispatched by `librdkafka` or timeout.
 
+### Upgrade notes
+
+Please note, this **is** a **breaking** release, hence `2.5.0`.
+
+1. If you used to catch `WaterDrop::Errors::FlushFailureError` now you need to catch `WaterDrop::Errors::ProduceError`. `WaterDrop::Errors::ProduceManyError` is based on the `ProduceError`, hence it should be enough.
+2. Prior to `2.5.0` there was always a chance of partial dispatches via `produce_many_` methods. Now you can get the info on all the errors via `error.occurred`.
+3. Inline `Rdkafka::RdkafkaError` are now re-raised via `WaterDrop::Errors::ProduceError` and available under `#cause`. Async `Rdkafka::RdkafkaError` errors are still directly available and you can differentiate between errors using the event `type`.
+
 ## 2.4.11 (2023-02-24)
 - Replace the local rspec locator with generalized core one.
 - Make `::WaterDrop::Instrumentation::Notifications::EVENTS` list public for anyone wanting to re-bind those into a different notification bus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # WaterDrop changelog
 
-## 2.4.12 (Unreleased)
+## 2.5.0 (Unreleased)
 - Pipe delivery errors that occurred not via the error callback using the `error.occurred` channel.
+- Pipe **all** the errors including synchronous errors via the `error.occurred`.
+- Remove the `WaterDrop::Errors::FlushFailureError` in favour of correct error that occurred to unify the error handling.
+- Introduce `WaterDrop::Errors::ProduceError` and `WaterDrop::Errors::ProduceManyError` for any inline raised errors that occur. You can get the original error by using the `#cause`.
+- Do **not** flush when there is no data to flush in the internal buffer.
 
 ## 2.4.11 (2023-02-24)
 - Replace the local rspec locator with generalized core one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # WaterDrop changelog
 
 ## 2.5.0 (Unreleased)
-- Pipe delivery errors that occurred not via the error callback using the `error.occurred` channel.
-- Pipe **all** the errors including synchronous errors via the `error.occurred`.
-- Remove the `WaterDrop::Errors::FlushFailureError` in favour of correct error that occurred to unify the error handling.
-- Introduce `WaterDrop::Errors::ProduceError` and `WaterDrop::Errors::ProduceManyError` for any inline raised errors that occur. You can get the original error by using the `#cause`.
-- Do **not** flush when there is no data to flush in the internal buffer.
-- Include `#dispatched` messages handler in the `WaterDrop::Errors::ProduceManyError` error, to be able to understand which of the messages were delegated to `librdkafka` prior to the failure.
+- [Feature] Pipe **all** the errors including synchronous errors via the `error.occurred`.
+- [Improvement] Pipe delivery errors that occurred not via the error callback using the `error.occurred` channel.
+- [Improvement] Introduce `WaterDrop::Errors::ProduceError` and `WaterDrop::Errors::ProduceManyError` for any inline raised errors that occur. You can get the original error by using the `#cause`.
+- [Improvement] Include `#dispatched` messages handler in the `WaterDrop::Errors::ProduceManyError` error, to be able to understand which of the messages were delegated to `librdkafka` prior to the failure.
+- [Maintenance] Remove the `WaterDrop::Errors::FlushFailureError` in favour of correct error that occurred to unify the error handling.
+- [Fix] Do **not** flush when there is no data to flush in the internal buffer.
+- [Fix] Wait on last dispatched message for super short-lived producers to make sure, that the message is actually dispatched by `librdkafka` or timeout.
 
 ## 2.4.11 (2023-02-24)
 - Replace the local rspec locator with generalized core one.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.4.11)
+    waterdrop (2.4.12)
       karafka-core (>= 2.0.12, < 3.0.0)
       zeitwerk (~> 2.3)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.4.12)
+    waterdrop (2.5.0)
       karafka-core (>= 2.0.12, < 3.0.0)
       zeitwerk (~> 2.3)
 

--- a/README.md
+++ b/README.md
@@ -387,6 +387,8 @@ end
 # WaterDrop error occurred: Local: Broker transport failure (transport)
 ```
 
+**Note:** `error.occurred` will also include any errors originating from `librdkafka` for synchronous operations, including those that are raised back to the end user.
+
 ### Acknowledgment notifications
 
 WaterDrop allows you to listen to Kafka messages' acknowledgment events. This will enable you to monitor deliveries of messages from WaterDrop even when using asynchronous dispatch methods.

--- a/lib/waterdrop/errors.rb
+++ b/lib/waterdrop/errors.rb
@@ -29,15 +29,18 @@ module WaterDrop
     # contact us as it is an error.
     StatusInvalidError = Class.new(BaseError)
 
-    # Raised when during messages flushing something bad happened
-    class FlushFailureError < BaseError
-      attr_reader :dispatched_messages
+    # Raised when there is an inline error during single message produce operations
+    ProduceError = Class.new(BaseError)
 
-      # @param dispatched_messages [Array<Rdkafka::Producer::DeliveryHandle>] handlers of the
+    # Raised when during messages producing something bad happened inline
+    class ProduceManyError < ProduceError
+      attr_reader :dispatched
+
+      # @param dispatched [Array<Rdkafka::Producer::DeliveryHandle>] handlers of the
       #   messages that we've dispatched
-      def initialize(dispatched_messages)
+      def initialize(dispatched)
         super()
-        @dispatched_messages = dispatched_messages
+        @dispatched = dispatched
       end
     end
   end

--- a/lib/waterdrop/instrumentation/callbacks/delivery.rb
+++ b/lib/waterdrop/instrumentation/callbacks/delivery.rb
@@ -35,7 +35,7 @@ module WaterDrop
             producer_id: @producer_id,
             offset: delivery_report.offset,
             partition: delivery_report.partition,
-            type: 'librdkafka.produce_error'
+            type: 'librdkafka.dispatch_error'
           )
         end
 

--- a/lib/waterdrop/instrumentation/callbacks/delivery.rb
+++ b/lib/waterdrop/instrumentation/callbacks/delivery.rb
@@ -17,6 +17,30 @@ module WaterDrop
         # Emits delivery details to the monitor
         # @param delivery_report [Rdkafka::Producer::DeliveryReport] delivery report
         def call(delivery_report)
+          if delivery_report.error.to_i.positive?
+            instrument_error(delivery_report)
+          else
+            instrument_acknowledged(delivery_report)
+          end
+        end
+
+        private
+
+        # @param delivery_report [Rdkafka::Producer::DeliveryReport] delivery report
+        def instrument_error(delivery_report)
+          @monitor.instrument(
+            'error.occurred',
+            caller: self,
+            error: ::Rdkafka::RdkafkaError.new(delivery_report.error),
+            producer_id: @producer_id,
+            offset: delivery_report.offset,
+            partition: delivery_report.partition,
+            type: 'librdkafka.produce_error'
+          )
+        end
+
+        # @param delivery_report [Rdkafka::Producer::DeliveryReport] delivery report
+        def instrument_acknowledged(delivery_report)
           @monitor.instrument(
             'message.acknowledged',
             producer_id: @producer_id,

--- a/lib/waterdrop/instrumentation/callbacks/error.rb
+++ b/lib/waterdrop/instrumentation/callbacks/error.rb
@@ -18,6 +18,8 @@ module WaterDrop
         # @param client_name [String] rdkafka client name
         # @param error [Rdkafka::Error] error that occurred
         # @note It will only instrument on errors of the client of our producer
+        # @note When there is a particular message produce error (not internal error), the error
+        #   is shipped via the delivery callback, not via error callback.
         def call(client_name, error)
           # Emit only errors related to our client
           # Same as with statistics (mor explanation there)

--- a/lib/waterdrop/patches/rdkafka/client.rb
+++ b/lib/waterdrop/patches/rdkafka/client.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module WaterDrop
+  module Patches
+    module Rdkafka
+      # Patches for the producer client
+      module Client
+        # @param _object_id [nil] rdkafka API compatibility argument
+        # @param timeout_ms [Integer] final flush timeout in ms
+        def close(_object_id = nil, timeout_ms = 5_000)
+          return unless @native
+
+          # Indicate to polling thread that we're closing
+          @polling_thread[:closing] = true
+          # Wait for the polling thread to finish up
+          @polling_thread.join
+
+          ::Rdkafka::Bindings.rd_kafka_flush(@native, timeout_ms)
+          ::Rdkafka::Bindings.rd_kafka_destroy(@native)
+
+          @native = nil
+        end
+      end
+    end
+  end
+end
+
+::Rdkafka::Bindings.attach_function(
+  :rd_kafka_flush,
+  %i[pointer int],
+  :void
+)
+
+Rdkafka::Producer::Client.prepend WaterDrop::Patches::Rdkafka::Client

--- a/lib/waterdrop/patches/rdkafka/producer.rb
+++ b/lib/waterdrop/patches/rdkafka/producer.rb
@@ -70,9 +70,22 @@ module WaterDrop
 
           @_inner_kafka
         end
+
+        # Flushes the buffered data and waits for its dispatch
+        # @param timeout_ms [Integer] wait time in ms
+        def flush(timeout_ms = 5_000)
+          ::Rdkafka::Bindings.rd_kafka_flush(inner_kafka, timeout_ms)
+        end
       end
     end
   end
 end
+
+::Rdkafka::Bindings.attach_function(
+  :rd_kafka_flush,
+  %i[pointer int],
+  :void,
+  blocking: true
+)
 
 ::Rdkafka::Producer.prepend ::WaterDrop::Patches::Rdkafka::Producer

--- a/lib/waterdrop/patches/rdkafka/producer.rb
+++ b/lib/waterdrop/patches/rdkafka/producer.rb
@@ -84,8 +84,7 @@ end
 ::Rdkafka::Bindings.attach_function(
   :rd_kafka_flush,
   %i[pointer int],
-  :void,
-  blocking: true
+  :void
 )
 
 ::Rdkafka::Producer.prepend ::WaterDrop::Patches::Rdkafka::Producer

--- a/lib/waterdrop/patches/rdkafka/producer.rb
+++ b/lib/waterdrop/patches/rdkafka/producer.rb
@@ -71,20 +71,16 @@ module WaterDrop
           @_inner_kafka
         end
 
-        # Flushes the buffered data and waits for its dispatch
-        # @param timeout_ms [Integer] wait time in ms
-        def flush(timeout_ms = 5_000)
-          ::Rdkafka::Bindings.rd_kafka_flush(inner_kafka, timeout_ms)
+        # Closes our librdkafka instance with the flush patch
+        # @param timeout_ms [Integer] flush timeout
+        def close(timeout_ms = 5_000)
+          ObjectSpace.undefine_finalizer(self)
+
+          @client.close(nil, timeout_ms)
         end
       end
     end
   end
 end
-
-::Rdkafka::Bindings.attach_function(
-  :rd_kafka_flush,
-  %i[pointer int],
-  :void
-)
 
 ::Rdkafka::Producer.prepend ::WaterDrop::Patches::Rdkafka::Producer

--- a/lib/waterdrop/producer.rb
+++ b/lib/waterdrop/producer.rb
@@ -133,17 +133,14 @@ module WaterDrop
           # as we close the client after the flushing (even if blocked by the mutex)
           flush(true)
 
-          # Ensures that the last dispatched message is delivered or failed prior to us finishing
-          # all the operations. This tackles a potential edge case, where we would have a super
-          # short-lived producer that would dispatch the message but close client fast enough
-          # for the last message to be lost
-          wait(@last_produced) if @last_produced
-
           # We should not close the client in several threads the same time
           # It is safe to run it several times but not exactly the same moment
           # We also mark it as closed only if it was connected, if not, it would trigger a new
           # connection that anyhow would be immediately closed
-          client.close if @client
+          if @client
+            client.flush(@config.max_wait_timeout)
+            client.close
+          end
 
           # Remove callbacks runners that were registered
           ::Karafka::Core::Instrumentation.statistics_callbacks.delete(@id)
@@ -178,7 +175,7 @@ module WaterDrop
     #
     # @param message [Hash] message we want to send
     def produce(message)
-      @last_produced = client.produce(**message)
+      client.produce(**message)
     end
 
     # Waits on a given handler

--- a/lib/waterdrop/producer.rb
+++ b/lib/waterdrop/producer.rb
@@ -8,6 +8,14 @@ module WaterDrop
     include Async
     include Buffer
 
+    # Which of the inline flow errors do we want to intercept and re-bind
+    SUPPORTED_FLOW_ERRORS = [
+      Rdkafka::RdkafkaError,
+      Rdkafka::Producer::DeliveryHandle::WaitTimeoutError
+    ].freeze
+
+    private_constant :SUPPORTED_FLOW_ERRORS
+
     def_delegators :config, :middleware
 
     # @return [String] uuid of the current producer
@@ -117,6 +125,10 @@ module WaterDrop
           # This should be used only in case a producer was not closed properly and forgotten
           ObjectSpace.undefine_finalizer(id)
 
+          # We save this thread id because we need to bypass the activity verification on the
+          # producer for final flush of buffers.
+          @closing_thread_id = Thread.current.object_id
+
           # Flush has its own buffer mutex but even if it is blocked, flushing can still happen
           # as we close the client after the flushing (even if blocked by the mutex)
           flush(true)
@@ -154,6 +166,23 @@ module WaterDrop
     # @raise [Karafka::Errors::MessageInvalidError]
     def validate_message!(message)
       @contract.validate!(message, Errors::MessageInvalidError)
+    end
+
+    # Runs the client produce method with a given message
+    #
+    # @param message [Hash] message we want to send
+    def produce(message)
+      client.produce(**message)
+    end
+
+    # Waits on a given handler
+    #
+    # @param handler [Rdkafka::Producer::DeliveryHandle]
+    def wait(handler)
+      handler.wait(
+        max_wait_timeout: @config.max_wait_timeout,
+        wait_timeout: @config.wait_timeout
+      )
     end
   end
 end

--- a/lib/waterdrop/producer.rb
+++ b/lib/waterdrop/producer.rb
@@ -137,10 +137,7 @@ module WaterDrop
           # It is safe to run it several times but not exactly the same moment
           # We also mark it as closed only if it was connected, if not, it would trigger a new
           # connection that anyhow would be immediately closed
-          if @client
-            client.flush(@config.max_wait_timeout)
-            client.close
-          end
+          client.close(@config.max_wait_timeout) if @client
 
           # Remove callbacks runners that were registered
           ::Karafka::Core::Instrumentation.statistics_callbacks.delete(@id)

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.4.11'
+  VERSION = '2.4.12'
 end

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.4.12'
+  VERSION = '2.5.0'
 end

--- a/spec/lib/waterdrop/errors_spec.rb
+++ b/spec/lib/waterdrop/errors_spec.rb
@@ -48,18 +48,4 @@ RSpec.describe_current do
 
     specify { expect(error).to be < described_class::BaseError }
   end
-
-  describe 'FlushFailureError' do
-    subject(:error) { described_class::FlushFailureError }
-
-    let(:messages) { [{ rand => rand }] }
-
-    specify { expect(error).to be < described_class::BaseError }
-
-    describe '#dispatched_messages' do
-      subject(:error) { described_class::FlushFailureError.new(messages) }
-
-      it { expect(error.dispatched_messages).to eq(messages) }
-    end
-  end
 end

--- a/spec/lib/waterdrop/instrumentation/callbacks/delivery_spec.rb
+++ b/spec/lib/waterdrop/instrumentation/callbacks/delivery_spec.rb
@@ -79,8 +79,6 @@ RSpec.describe_current do
         rescue Rdkafka::RdkafkaError
           nil
         end
-
-        sleep(0.01) until changed.size.positive?
       end
 
       it { expect(event.payload[:error]).to be_a(Rdkafka::RdkafkaError) }

--- a/spec/lib/waterdrop/instrumentation/callbacks/delivery_spec.rb
+++ b/spec/lib/waterdrop/instrumentation/callbacks/delivery_spec.rb
@@ -90,18 +90,7 @@ RSpec.describe_current do
       let(:changed) { [] }
       let(:errors) { [] }
       let(:event) { changed.first }
-      let(:producer) do
-        build(
-          :producer,
-          kafka: {
-            'bootstrap.servers': 'localhost:9092',
-            'request.required.acks': 1,
-            # Those will cause inline buffer overflow
-            'queue.buffering.max.messages': 1,
-            'queue.buffering.max.ms': 10_000
-          }
-        )
-      end
+      let(:producer) { build(:limited_producer) }
 
       before do
         producer.monitor.subscribe('error.occurred') do |event|

--- a/spec/lib/waterdrop/instrumentation/callbacks/delivery_spec.rb
+++ b/spec/lib/waterdrop/instrumentation/callbacks/delivery_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe_current do
         # Intercept the error so it won't bubble up as we want to check the notifications pipeline
         begin
           producer.send(:client).produce(topic: '$%^&*', payload: '1').wait
-        rescue => e
+        rescue Rdkafka::RdkafkaError
           nil
         end
 

--- a/spec/lib/waterdrop/producer/buffer_spec.rb
+++ b/spec/lib/waterdrop/producer/buffer_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe WaterDrop::Producer::Buffer do
         producer.buffer(create(:valid_message))
       end
 
-      it { expect { flushing }.to raise_error(WaterDrop::Errors::FlushFailureError) }
+      it { expect { flushing }.to raise_error(WaterDrop::Errors::ProduceManyError) }
     end
   end
 
@@ -127,7 +127,7 @@ RSpec.describe WaterDrop::Producer::Buffer do
         producer.buffer(create(:valid_message))
       end
 
-      it { expect { flushing }.to raise_error(WaterDrop::Errors::FlushFailureError) }
+      it { expect { flushing }.to raise_error(WaterDrop::Errors::ProduceManyError) }
     end
   end
 end

--- a/spec/lib/waterdrop/producer/sync_spec.rb
+++ b/spec/lib/waterdrop/producer/sync_spec.rb
@@ -23,9 +23,14 @@ RSpec.describe_current do
     context 'when inline error occurs in librdkafka' do
       let(:errors) { [] }
       let(:error) { errors.first }
+      let(:occurred) { [] }
       let(:producer) { build(:limited_producer) }
 
       before do
+        producer.monitor.subscribe('error.occurred') do |event|
+          occurred << event
+        end
+
         message = build(:valid_message)
         threads = Array.new(20) do
           Thread.new do
@@ -40,6 +45,8 @@ RSpec.describe_current do
 
       it { expect(error).to be_a(WaterDrop::Errors::ProduceError) }
       it { expect(error.cause).to be_a(Rdkafka::RdkafkaError) }
+      it { expect(occurred.last.payload[:error].cause).to be_a(Rdkafka::RdkafkaError) }
+      it { expect(occurred.last.payload[:type]).to eq('message.produce_sync') }
     end
   end
 

--- a/spec/lib/waterdrop/producer/sync_spec.rb
+++ b/spec/lib/waterdrop/producer/sync_spec.rb
@@ -19,6 +19,28 @@ RSpec.describe_current do
 
       it { expect(delivery).to be_a(Rdkafka::Producer::DeliveryReport) }
     end
+
+    context 'when inline error occurs in librdkafka' do
+      let(:errors) { [] }
+      let(:error) { errors.first }
+      let(:producer) { build(:limited_producer) }
+
+      before do
+        message = build(:valid_message)
+        threads = Array.new(20) do
+          Thread.new do
+            producer.produce_sync(message)
+          rescue StandardError => e
+            errors << e
+          end
+        end
+
+        threads.each(&:join)
+      end
+
+      it { expect(error).to be_a(WaterDrop::Errors::ProduceError) }
+      it { expect(error.cause).to be_a(Rdkafka::RdkafkaError) }
+    end
   end
 
   describe '#produce_sync with partition key' do

--- a/spec/support/factories/producer.rb
+++ b/spec/support/factories/producer.rb
@@ -29,4 +29,16 @@ FactoryBot.define do
       instance
     end
   end
+
+  factory :limited_producer, parent: :producer do
+    kafka do
+      {
+        'bootstrap.servers': 'localhost:9092',
+        'request.required.acks': 1,
+        # Those will cause inline buffer overflow
+        'queue.buffering.max.messages': 1,
+        'queue.buffering.max.ms': 10_000
+      }
+    end
+  end
 end


### PR DESCRIPTION
This PR does several things (taken from readme):

- Pipe delivery errors that occurred not via the error callback using the `error.occurred` channel.
- Pipe **all** the errors including synchronous errors via the `error.occurred`.
- Remove the `WaterDrop::Errors::FlushFailureError` in favour of correct error that occurred to unify the error handling.
- Introduce `WaterDrop::Errors::ProduceError` and `WaterDrop::Errors::ProduceManyError` for any inline raised errors that occur. You can get the original error by using the `#cause`.
- Do **not** flush when there is no data to flush in the internal buffer.

close https://github.com/karafka/waterdrop/issues/322