### PR TITLE
Add WaterDrop::Testing::SpecKafkaClient

### DIFF
--- a/lib/waterdrop/testing.rb
+++ b/lib/waterdrop/testing.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module WaterDrop
+  # Namespace for testing helpers
+  module Testing
+  end
+end

--- a/lib/waterdrop/testing/spec_kafka_client.rb
+++ b/lib/waterdrop/testing/spec_kafka_client.rb
@@ -1,4 +1,6 @@
- module WaterDrop
+# frozen_string_literal: true
+
+module WaterDrop
   module Testing
     # Spec producer client used to buffer messages that we send out in specs
     class SpecKafkaClient < Producer::DummyClient
@@ -18,7 +20,7 @@
         @topics = Hash.new { |k, v| k[v] = [] }
       end
 
-      # "Produces" message to Kafka. That is, it acknowledges it locally, adds it to the internal buffer
+      # "Produces" message to Kafka: it acknowledges it locally, adds it to the internal buffer
       # @param message [Hash] `WaterDrop::Producer#produce_sync` message hash
       def produce(message)
         topic = message.fetch(:topic) { raise ArgumentError, ':topic is missing' }

--- a/lib/waterdrop/testing/spec_kafka_client.rb
+++ b/lib/waterdrop/testing/spec_kafka_client.rb
@@ -1,0 +1,44 @@
+ module WaterDrop
+  module Testing
+    # Spec producer client used to buffer messages that we send out in specs
+    class SpecKafkaClient < Producer::DummyClient
+      attr_accessor :messages
+
+      # Sync fake response for the message delivery to Kafka, since we do not dispatch anything
+      class SyncResponse
+        # @param _args Handler wait arguments (irrelevant as waiting is fake here)
+        def wait(*_args)
+          false
+        end
+      end
+
+      def initialize
+        super()
+        @messages = []
+        @topics = Hash.new { |k, v| k[v] = [] }
+      end
+
+      # "Produces" message to Kafka. That is, it acknowledges it locally, adds it to the internal buffer
+      # @param message [Hash] `WaterDrop::Producer#produce_sync` message hash
+      def produce(message)
+        topic = message.fetch(:topic) { raise ArgumentError, ':topic is missing' }
+        @topics[topic] << message
+        @messages << message
+        SyncResponse.new
+      end
+
+      # Returns messages produced to a given topic
+      # @param topic [String]
+      def messages_for(topic)
+        @topics[topic]
+      end
+
+      # Clears internal buffer
+      # Used in between specs so messages do not leak out
+      def reset
+        @messages.clear
+        @topics.each_value(&:clear)
+      end
+    end
+  end
+end

--- a/spec/lib/waterdrop/testing/spec_kafka_client_spec.rb
+++ b/spec/lib/waterdrop/testing/spec_kafka_client_spec.rb
@@ -18,36 +18,48 @@ RSpec.describe_current do
     producer.produce_sync(payload: 'two', topic: 'foo')
   end
 
-  it 'memorizes produced messages' do
-    expect(client.messages).to match(
-      [
-        {payload: 'one', topic: 'foo'},
-        {payload: 'one', topic: 'bar'},
-        {payload: 'two', topic: 'foo'}
-      ]
-    )
-    expect(client.messages_for('foo')).to match(
-      [
-        {payload: 'one', topic: 'foo'},
-        {payload: 'two', topic: 'foo'}
-      ]
-    )
-    expect(client.messages_for('bar')).to match(
-      [
-        {payload: 'one', topic: 'bar'}
-      ]
-    )
-    expect(client.messages_for('buzz')).to be_empty
+  describe '#messages' do
+    it 'yields all produced messages' do
+      expect(client.messages).to match(
+        [
+          { payload: 'one', topic: 'foo' },
+          { payload: 'one', topic: 'bar' },
+          { payload: 'two', topic: 'foo' }
+        ]
+      )
+    end
   end
 
+  describe '#messages_for' do
+    context 'with topic that has messages produced to' do
+      it 'yields corresponding messages' do
+        expect(client.messages_for('foo')).to match(
+          [
+            { payload: 'one', topic: 'foo' },
+            { payload: 'two', topic: 'foo' }
+          ]
+        )
+        expect(client.messages_for('bar')).to match(
+          [
+            { payload: 'one', topic: 'bar' }
+          ]
+        )
+      end
+    end
+
+    context 'when topic that was not produced to' do
+      it 'yields no messages' do
+        expect(client.messages_for('buzz')).to be_empty
+      end
+    end
+
+  end
   describe '#reset' do
-    it 'clears the buffers' do
+    it 'clears all buffers' do
       client.reset
 
       expect(client.messages).to be_empty
       expect(client.messages_for('foo')).to be_empty
-      expect(client.messages_for('bar')).to be_empty
-      expect(client.messages_for('buzz')).to be_empty
     end
   end
 end

--- a/spec/lib/waterdrop/testing/spec_kafka_client_spec.rb
+++ b/spec/lib/waterdrop/testing/spec_kafka_client_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:client) { described_class.new }
+
+  let(:producer) do
+    WaterDrop::Producer.new do |config|
+      config.deliver = false
+      config.kafka = { 'bootstrap.servers': 'localhost:9092' }
+    end
+  end
+
+  before do
+    allow(producer).to receive(:client).and_return(client)
+
+    producer.produce_sync(payload: 'one', topic: 'foo')
+    producer.produce_sync(payload: 'one', topic: 'bar')
+    producer.produce_sync(payload: 'two', topic: 'foo')
+  end
+
+  it 'memorizes produced messages' do
+    expect(client.messages).to match(
+      [
+        {payload: 'one', topic: 'foo'},
+        {payload: 'one', topic: 'bar'},
+        {payload: 'two', topic: 'foo'}
+      ]
+    )
+    expect(client.messages_for('foo')).to match(
+      [
+        {payload: 'one', topic: 'foo'},
+        {payload: 'two', topic: 'foo'}
+      ]
+    )
+    expect(client.messages_for('bar')).to match(
+      [
+        {payload: 'one', topic: 'bar'}
+      ]
+    )
+    expect(client.messages_for('buzz')).to be_empty
+  end
+
+  describe '#reset' do
+    it 'clears the buffers' do
+      client.reset
+
+      expect(client.messages).to be_empty
+      expect(client.messages_for('foo')).to be_empty
+      expect(client.messages_for('bar')).to be_empty
+      expect(client.messages_for('buzz')).to be_empty
+    end
+  end
+end

--- a/spec/lib/waterdrop/testing/spec_kafka_client_spec.rb
+++ b/spec/lib/waterdrop/testing/spec_kafka_client_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe_current do
         expect(client.messages_for('buzz')).to be_empty
       end
     end
-
   end
+
   describe '#reset' do
     it 'clears all buffers' do
       client.reset

--- a/spec/lib/waterdrop/testing/spec_kafka_client_spec.rb
+++ b/spec/lib/waterdrop/testing/spec_kafka_client_spec.rb
@@ -10,6 +10,27 @@ RSpec.describe_current do
     end
   end
 
+  let(:all_messages) do
+    [
+      { payload: 'one', topic: 'foo' },
+      { payload: 'one', topic: 'bar' },
+      { payload: 'two', topic: 'foo' }
+    ]
+  end
+
+  let(:foo_messages) do
+    [
+      { payload: 'one', topic: 'foo' },
+      { payload: 'two', topic: 'foo' }
+    ]
+  end
+
+  let(:bar_messages) do
+    [
+      { payload: 'one', topic: 'bar' },
+    ]
+  end
+
   before do
     allow(producer).to receive(:client).and_return(client)
 
@@ -20,30 +41,15 @@ RSpec.describe_current do
 
   describe '#messages' do
     it 'yields all produced messages' do
-      expect(client.messages).to match(
-        [
-          { payload: 'one', topic: 'foo' },
-          { payload: 'one', topic: 'bar' },
-          { payload: 'two', topic: 'foo' }
-        ]
-      )
+      expect(client.messages).to match(all_messages)
     end
   end
 
   describe '#messages_for' do
     context 'with topic that has messages produced to' do
       it 'yields corresponding messages' do
-        expect(client.messages_for('foo')).to match(
-          [
-            { payload: 'one', topic: 'foo' },
-            { payload: 'two', topic: 'foo' }
-          ]
-        )
-        expect(client.messages_for('bar')).to match(
-          [
-            { payload: 'one', topic: 'bar' }
-          ]
-        )
+        expect(client.messages_for('foo')).to match(foo_messages)
+        expect(client.messages_for('bar')).to match(bar_messages)
       end
     end
 

--- a/spec/lib/waterdrop/testing/spec_kafka_client_spec.rb
+++ b/spec/lib/waterdrop/testing/spec_kafka_client_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe_current do
 
   let(:bar_messages) do
     [
-      { payload: 'one', topic: 'bar' },
+      { payload: 'one', topic: 'bar' }
     ]
   end
 

--- a/spec/lib/waterdrop/testing/spec_kafka_client_spec.rb
+++ b/spec/lib/waterdrop/testing/spec_kafka_client_spec.rb
@@ -40,32 +40,26 @@ RSpec.describe_current do
   end
 
   describe '#messages' do
-    it 'yields all produced messages' do
-      expect(client.messages).to match(all_messages)
-    end
+    subject { client.messages }
+
+    it { is_expected.to match(all_messages) }
   end
 
   describe '#messages_for' do
-    context 'with topic that has messages produced to' do
-      it 'yields corresponding messages' do
-        expect(client.messages_for('foo')).to match(foo_messages)
-        expect(client.messages_for('bar')).to match(bar_messages)
-      end
+    context 'with topic that has messages produced to it' do
+      it { expect(client.messages_for('foo')).to match(foo_messages) }
+      it { expect(client.messages_for('bar')).to match(bar_messages) }
     end
 
-    context 'when topic that was not produced to' do
-      it 'yields no messages' do
-        expect(client.messages_for('buzz')).to be_empty
-      end
+    context 'with topic that has no messages produced to it' do
+      it { expect(client.messages_for('buzz')).to be_empty }
     end
   end
 
   describe '#reset' do
-    it 'clears all buffers' do
-      client.reset
+    before { client.reset }
 
-      expect(client.messages).to be_empty
-      expect(client.messages_for('foo')).to be_empty
-    end
+    it { expect(client.messages).to be_empty }
+    it { expect(client.messages_for('foo')).to be_empty }
   end
 end

--- a/spec/lib/waterdrop/testing_spec.rb
+++ b/spec/lib/waterdrop/testing_spec.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+# Nothing really here. Just a stub for Coditsu


### PR DESCRIPTION
Add a helper client to use in tests to monitor produced messages.
It is based on [the similar class](https://github.com/karafka/karafka-testing/blob/master/lib/karafka/testing/spec_producer_client.rb) from `karafka-testing` but is simplified and is aimed for producer-only apps.