### PR TITLE
improve queue backoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@
 ### 2.6.0 (Unreleased)
 - [Improvement] Make `#produce` method private to avoid confusion and make sure it is not used directly (it is not part of the official API).
 - [Change] Change `wait_on_queue_full` from `false` to `true` as a default.
-- [Change] Rename `wait_on_queue_full_timeout` to `wait_on_queue_full_backoff` to match what it actually does.
-- [Enhancement] Reintroduce `wait_on_queue_full_timeout` with proper meaning. That is, this represents time after which despite backoff the error will be raised. This should allow to raise an error in case the backoff attempts were insufficient. This prevents from a case, where upon never deliverable messages we would end up with an invite loop.
+- [Change] Rename `wait_on_queue_full_timeout` to `wait_backoff_on_queue_full` to match what it actually does.
+- [Enhancement] Introduce `wait_timeout_on_queue_full` with proper meaning. That is, this represents time after which despite backoff the error will be raised. This should allow to raise an error in case the backoff attempts were insufficient. This prevents from a case, where upon never deliverable messages we would end up with an invite loop.
 - [Fix] Provide `type` for queue full errors that references the appropriate public API method correctly.
+
+### Upgrade notes
+
+1. Rename `wait_on_queue_full_timeout` to `wait_backoff_on_queue_full`.
+2. Set `wait_on_queue_full` to `false` if you did not use it and do not want.
 
 ## 2.5.3 (2023-05-26)
 - [Enhancement] Include topic name in the `error.occurred` notification payload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # WaterDrop changelog
 
+### 2.6.0 (Unreleased)
+- [Improvement] Make `#produce` method private to avoid confusion and make sure it is not used directly (it is not part of the official API).
+- [Change] Change `wait_on_queue_full` from `false` to `true` as a default.
+- [Change] Rename `wait_on_queue_full_timeout` to `wait_on_queue_full_backoff` to match what it actually does.
+- [Enhancement] Reintroduce `wait_on_queue_full_timeout` with proper meaning. That is, this represents time after which despite backoff the error will be raised. This should allow to raise an error in case the backoff attempts were insufficient. This prevents from a case, where upon never deliverable messages we would end up with an invite loop.
+- [Fix] Provide `type` for queue full errors that references the appropriate public API method correctly.
+
 ## 2.5.3 (2023-05-26)
-- Require `karafka-core` `2.0.13`
-- Include topic name in the `error.occurred` notification payload.
-- Include topic name in the `message.acknowledged` notification payload.
+- [Enhancement] Include topic name in the `error.occurred` notification payload.
+- [Enhancement] Include topic name in the `message.acknowledged` notification payload.
+- [Maintenance] Require `karafka-core` `2.0.13`
 
 ## 2.5.2 (2023-04-24)
 - [Fix] Require missing Pathname (#345)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.5.3)
+    waterdrop (2.6.0)
       karafka-core (>= 2.0.13, < 3.0.0)
       zeitwerk (~> 2.3)
 

--- a/README.md
+++ b/README.md
@@ -93,15 +93,16 @@ end
 
 Some of the options are:
 
-| Option                       | Description                                                      |
-|------------------------------|------------------------------------------------------------------|
-| `id`                         | id of the producer for instrumentation and logging               |
-| `logger`                     | Logger that we want to use                                       |
-| `deliver`                    | Should we send messages to Kafka or just fake the delivery       |
-| `max_wait_timeout`           | Waits that long for the delivery report or raises an error       |
-| `wait_timeout`               | Waits that long before re-check of delivery report availability  |
-| `wait_on_queue_full`         | Should be wait on queue full or raise an error when that happens |
-| `wait_on_queue_full_timeout` | Waits that long before retry when queue is full                  |
+| Option                       | Description                                                               |
+|------------------------------|---------------------------------------------------------------------------|
+| `id`                         | id of the producer for instrumentation and logging                        |
+| `logger`                     | Logger that we want to use                                                |
+| `deliver`                    | Should we send messages to Kafka or just fake the delivery                |
+| `max_wait_timeout`           | Waits that long for the delivery report or raises an error                |
+| `wait_timeout`               | Waits that long before re-check of delivery report availability           |
+| `wait_on_queue_full`         | Should be wait on queue full or raise an error when that happens          |
+| `wait_on_queue_full_backoff` | Waits that long before retry when queue is full                           |
+| `wait_on_queue_full_timeout` | If backoffs and attempts that that much time, error won't be retried more |
 
 Full list of the root configuration options is available [here](https://github.com/karafka/waterdrop/blob/master/lib/waterdrop/config.rb#L25).
 

--- a/README.md
+++ b/README.md
@@ -93,16 +93,16 @@ end
 
 Some of the options are:
 
-| Option                       | Description                                                               |
-|------------------------------|---------------------------------------------------------------------------|
-| `id`                         | id of the producer for instrumentation and logging                        |
-| `logger`                     | Logger that we want to use                                                |
-| `deliver`                    | Should we send messages to Kafka or just fake the delivery                |
-| `max_wait_timeout`           | Waits that long for the delivery report or raises an error                |
-| `wait_timeout`               | Waits that long before re-check of delivery report availability           |
-| `wait_on_queue_full`         | Should be wait on queue full or raise an error when that happens          |
-| `wait_on_queue_full_backoff` | Waits that long before retry when queue is full                           |
-| `wait_on_queue_full_timeout` | If backoffs and attempts that that much time, error won't be retried more |
+| Option                       | Description                                                                |
+|------------------------------|----------------------------------------------------------------------------|
+| `id`                         | id of the producer for instrumentation and logging                         |
+| `logger`                     | Logger that we want to use                                                 |
+| `deliver`                    | Should we send messages to Kafka or just fake the delivery                 |
+| `max_wait_timeout`           | Waits that long for the delivery report or raises an error                 |
+| `wait_timeout`               | Waits that long before re-check of delivery report availability            |
+| `wait_on_queue_full`         | Should be wait on queue full or raise an error when that happens           |
+| `wait_on_queue_full_backoff` | Waits that long before retry when queue is full                            |
+| `wait_on_queue_full_timeout` | If back-offs and attempts that that much time, error won't be retried more |
 
 Full list of the root configuration options is available [here](https://github.com/karafka/waterdrop/blob/master/lib/waterdrop/config.rb#L25).
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Some of the options are:
 | `max_wait_timeout`           | Waits that long for the delivery report or raises an error                 |
 | `wait_timeout`               | Waits that long before re-check of delivery report availability            |
 | `wait_on_queue_full`         | Should be wait on queue full or raise an error when that happens           |
-| `wait_on_queue_full_backoff` | Waits that long before retry when queue is full                            |
-| `wait_on_queue_full_timeout` | If back-offs and attempts that that much time, error won't be retried more |
+| `wait_backoff_on_queue_full` | Waits that long before retry when queue is full                            |
+| `wait_timeout_on_queue_full` | If back-offs and attempts that that much time, error won't be retried more |
 
 Full list of the root configuration options is available [here](https://github.com/karafka/waterdrop/blob/master/lib/waterdrop/config.rb#L25).
 

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -11,8 +11,8 @@ en:
       kafka_format: must be a hash with symbol based keys
       kafka_key_must_be_a_symbol: All keys under the kafka settings scope need to be symbols
       wait_on_queue_full_format: must be boolean
-      wait_on_queue_full_backoff_format: must be a numeric that is bigger or equal to 0
-      wait_on_queue_full_timeout_format: must be a numeric that is bigger or equal to 0
+      wait_backoff_on_queue_full_format: must be a numeric that is bigger or equal to 0
+      wait_timeout_on_queue_full_format: must be a numeric that is bigger or equal to 0
 
     message:
       missing: must be present

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -10,6 +10,9 @@ en:
       max_wait_timeout_format: must be an integer that is equal or bigger than 0
       kafka_format: must be a hash with symbol based keys
       kafka_key_must_be_a_symbol: All keys under the kafka settings scope need to be symbols
+      wait_on_queue_full_format: must be boolean
+      wait_on_queue_full_backoff_format: must be a numeric that is bigger or equal to 0
+      wait_on_queue_full_timeout_format: must be a numeric that is bigger or equal to 0
 
     message:
       missing: must be present

--- a/lib/waterdrop/config.rb
+++ b/lib/waterdrop/config.rb
@@ -56,11 +56,14 @@ module WaterDrop
     #   in the `error.occurred` notification pipeline with a proper type as while this is
     #   recoverable, in a high number it still may mean issues.
     #   Waiting is one of the recommended strategies.
-    setting :wait_on_queue_full, default: false
+    setting :wait_on_queue_full, default: true
     # option [Integer] how long (in seconds) should we backoff before a retry when queue is full
     #   The retry will happen with the same message and backoff should give us some time to
     #   dispatch previously buffered messages.
-    setting :wait_on_queue_full_timeout, default: 0.1
+    setting :wait_on_queue_full_backoff, default: 0.1
+    # option [Numeric] how many seconds should we wait with the backoff on queue having space for
+    # more messages before re-raising the error.
+    setting :wait_on_queue_full_timeout, default: 10
     # option [Boolean] should we send messages. Setting this to false can be really useful when
     #   testing and or developing because when set to false, won't actually ping Kafka but will
     #   run all the validations, etc

--- a/lib/waterdrop/config.rb
+++ b/lib/waterdrop/config.rb
@@ -60,10 +60,10 @@ module WaterDrop
     # option [Integer] how long (in seconds) should we backoff before a retry when queue is full
     #   The retry will happen with the same message and backoff should give us some time to
     #   dispatch previously buffered messages.
-    setting :wait_on_queue_full_backoff, default: 0.1
+    setting :wait_backoff_on_queue_full, default: 0.1
     # option [Numeric] how many seconds should we wait with the backoff on queue having space for
     # more messages before re-raising the error.
-    setting :wait_on_queue_full_timeout, default: 10
+    setting :wait_timeout_on_queue_full, default: 10
     # option [Boolean] should we send messages. Setting this to false can be really useful when
     #   testing and or developing because when set to false, won't actually ping Kafka but will
     #   run all the validations, etc

--- a/lib/waterdrop/contracts/config.rb
+++ b/lib/waterdrop/contracts/config.rb
@@ -20,8 +20,8 @@ module WaterDrop
       required(:wait_timeout) { |val| val.is_a?(Numeric) && val.positive? }
       required(:kafka) { |val| val.is_a?(Hash) && !val.empty? }
       required(:wait_on_queue_full) { |val| [true, false].include?(val) }
-      required(:wait_on_queue_full_backoff) { |val| val.is_a?(Numeric) && val >= 0 }
-      required(:wait_on_queue_full_timeout) { |val| val.is_a?(Numeric) && val >= 0 }
+      required(:wait_backoff_on_queue_full) { |val| val.is_a?(Numeric) && val >= 0 }
+      required(:wait_timeout_on_queue_full) { |val| val.is_a?(Numeric) && val >= 0 }
 
       # rdkafka allows both symbols and strings as keys for config but then casts them to strings
       # This can be confusing, so we expect all keys to be symbolized

--- a/lib/waterdrop/contracts/config.rb
+++ b/lib/waterdrop/contracts/config.rb
@@ -19,6 +19,9 @@ module WaterDrop
       required(:max_wait_timeout) { |val| val.is_a?(Numeric) && val >= 0 }
       required(:wait_timeout) { |val| val.is_a?(Numeric) && val.positive? }
       required(:kafka) { |val| val.is_a?(Hash) && !val.empty? }
+      required(:wait_on_queue_full) { |val| [true, false].include?(val) }
+      required(:wait_on_queue_full_backoff) { |val| val.is_a?(Numeric) && val >= 0 }
+      required(:wait_on_queue_full_timeout) { |val| val.is_a?(Numeric) && val >= 0 }
 
       # rdkafka allows both symbols and strings as keys for config but then casts them to strings
       # This can be confusing, so we expect all keys to be symbolized

--- a/lib/waterdrop/producer.rb
+++ b/lib/waterdrop/producer.rb
@@ -195,7 +195,7 @@ module WaterDrop
       # If we're running for longer than the timeout, we need to re-raise the queue full.
       # This will prevent from situation where cluster is down forever and we just retry and retry
       # in an infinite loop, effectively hanging the processing
-      raise unless monotonic_now - produce_time < @config.wait_on_queue_full_timeout * 1_000
+      raise unless monotonic_now - produce_time < @config.wait_timeout_on_queue_full * 1_000
 
       label = caller_locations(2, 1)[0].label.split(' ').last
 
@@ -221,7 +221,7 @@ module WaterDrop
 
         # We do not poll the producer because polling happens in a background thread
         # It also should not be a frequent case (queue full), hence it's ok to just throttle.
-        sleep @config.wait_on_queue_full_backoff
+        sleep @config.wait_backoff_on_queue_full
       end
 
       retry

--- a/lib/waterdrop/producer.rb
+++ b/lib/waterdrop/producer.rb
@@ -197,7 +197,7 @@ module WaterDrop
       # in an infinite loop, effectively hanging the processing
       raise unless monotonic_now - produce_time < @config.wait_on_queue_full_timeout * 1_000
 
-      label = caller_locations(2,1)[0].label.split(' ').last
+      label = caller_locations(2, 1)[0].label.split(' ').last
 
       # We use this syntax here because we want to preserve the original `#cause` when we
       # instrument the error and there is no way to manually assign `#cause` value. We want to keep

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.5.3'
+  VERSION = '2.6.0'
 end

--- a/spec/lib/waterdrop/contracts/config_spec.rb
+++ b/spec/lib/waterdrop/contracts/config_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe_current do
       max_payload_size: 1024 * 1024,
       max_wait_timeout: 1,
       wait_timeout: 0.1,
+      wait_on_queue_full: true,
+      wait_on_queue_full_backoff: 1,
+      wait_on_queue_full_timeout: 10,
       kafka: {
         'bootstrap.servers': 'localhost:9092,localhots:9092'
       }
@@ -230,5 +233,40 @@ RSpec.describe_current do
     before { config[:wait_timeout] = 1.1 }
 
     it { expect(contract_result).to be_success }
+  end
+
+  context 'when wait_on_queue_full is not a boolean' do
+    before { config[:wait_on_queue_full] = 0 }
+
+    it { expect(contract_result).not_to be_success }
+    it { expect(contract_errors[:wait_on_queue_full]).not_to be_empty }
+  end
+
+  context 'when wait_on_queue_full_backoff is not a numeric' do
+    before { config[:wait_on_queue_full_backoff] = 'na' }
+
+    it { expect(contract_result).not_to be_success }
+    it { expect(contract_errors[:wait_on_queue_full_backoff]).not_to be_empty }
+  end
+
+  context 'when wait_on_queue_full_backoff is less than 0' do
+    before { config[:wait_on_queue_full_backoff] = -1 }
+
+    it { expect(contract_result).not_to be_success }
+    it { expect(contract_errors[:wait_on_queue_full_backoff]).not_to be_empty }
+  end
+
+  context 'when wait_on_queue_full_timeout is not a numeric' do
+    before { config[:wait_on_queue_full_timeout] = 'na' }
+
+    it { expect(contract_result).not_to be_success }
+    it { expect(contract_errors[:wait_on_queue_full_timeout]).not_to be_empty }
+  end
+
+  context 'when wait_on_queue_full_timeout is less than 0' do
+    before { config[:wait_on_queue_full_timeout] = -1 }
+
+    it { expect(contract_result).not_to be_success }
+    it { expect(contract_errors[:wait_on_queue_full_timeout]).not_to be_empty }
   end
 end

--- a/spec/lib/waterdrop/contracts/config_spec.rb
+++ b/spec/lib/waterdrop/contracts/config_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe_current do
       max_wait_timeout: 1,
       wait_timeout: 0.1,
       wait_on_queue_full: true,
-      wait_on_queue_full_backoff: 1,
-      wait_on_queue_full_timeout: 10,
+      wait_backoff_on_queue_full: 1,
+      wait_timeout_on_queue_full: 10,
       kafka: {
         'bootstrap.servers': 'localhost:9092,localhots:9092'
       }
@@ -242,31 +242,31 @@ RSpec.describe_current do
     it { expect(contract_errors[:wait_on_queue_full]).not_to be_empty }
   end
 
-  context 'when wait_on_queue_full_backoff is not a numeric' do
-    before { config[:wait_on_queue_full_backoff] = 'na' }
+  context 'when wait_backoff_on_queue_full is not a numeric' do
+    before { config[:wait_backoff_on_queue_full] = 'na' }
 
     it { expect(contract_result).not_to be_success }
-    it { expect(contract_errors[:wait_on_queue_full_backoff]).not_to be_empty }
+    it { expect(contract_errors[:wait_backoff_on_queue_full]).not_to be_empty }
   end
 
-  context 'when wait_on_queue_full_backoff is less than 0' do
-    before { config[:wait_on_queue_full_backoff] = -1 }
+  context 'when wait_backoff_on_queue_full is less than 0' do
+    before { config[:wait_backoff_on_queue_full] = -1 }
 
     it { expect(contract_result).not_to be_success }
-    it { expect(contract_errors[:wait_on_queue_full_backoff]).not_to be_empty }
+    it { expect(contract_errors[:wait_backoff_on_queue_full]).not_to be_empty }
   end
 
-  context 'when wait_on_queue_full_timeout is not a numeric' do
-    before { config[:wait_on_queue_full_timeout] = 'na' }
+  context 'when wait_timeout_on_queue_full is not a numeric' do
+    before { config[:wait_timeout_on_queue_full] = 'na' }
 
     it { expect(contract_result).not_to be_success }
-    it { expect(contract_errors[:wait_on_queue_full_timeout]).not_to be_empty }
+    it { expect(contract_errors[:wait_timeout_on_queue_full]).not_to be_empty }
   end
 
-  context 'when wait_on_queue_full_timeout is less than 0' do
-    before { config[:wait_on_queue_full_timeout] = -1 }
+  context 'when wait_timeout_on_queue_full is less than 0' do
+    before { config[:wait_timeout_on_queue_full] = -1 }
 
     it { expect(contract_result).not_to be_success }
-    it { expect(contract_errors[:wait_on_queue_full_timeout]).not_to be_empty }
+    it { expect(contract_errors[:wait_timeout_on_queue_full]).not_to be_empty }
   end
 end

--- a/spec/lib/waterdrop/producer/async_spec.rb
+++ b/spec/lib/waterdrop/producer/async_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe_current do
         build(
           :slow_producer,
           wait_on_queue_full: true,
-          wait_on_queue_full_timeout: 0.5
+          wait_timeout_on_queue_full: 0.5
         )
       end
 

--- a/spec/lib/waterdrop/producer/async_spec.rb
+++ b/spec/lib/waterdrop/producer/async_spec.rb
@@ -77,15 +77,15 @@ RSpec.describe_current do
 
       it { expect(error).to be_a(WaterDrop::Errors::ProduceError) }
       it { expect(error.cause).to be_a(Rdkafka::RdkafkaError) }
-      it { expect(occurred.last.payload[:error].cause).to be_a(Rdkafka::RdkafkaError) }
-      it { expect(occurred.last.payload[:type]).to eq('message.produce_async') }
+      it { expect(occurred.first.payload[:error].cause).to be_a(Rdkafka::RdkafkaError) }
+      it { expect(occurred.first.payload[:type]).to eq('message.produce_async') }
     end
 
     context 'when inline error occurs in librdkafka and we retry on queue full' do
       let(:errors) { [] }
       let(:occurred) { [] }
       let(:error) { errors.first }
-      let(:producer) { build(:slow_producer) }
+      let(:producer) { build(:slow_producer, wait_on_queue_full: true) }
 
       before do
         producer.config.wait_on_queue_full = true
@@ -103,8 +103,40 @@ RSpec.describe_current do
       end
 
       it { expect(errors).to be_empty }
-      it { expect(occurred.last.payload[:error].cause).to be_a(Rdkafka::RdkafkaError) }
-      it { expect(occurred.last.payload[:type]).to eq('message.produce') }
+      it { expect(occurred.first.payload[:error].cause).to be_a(Rdkafka::RdkafkaError) }
+      it { expect(occurred.first.payload[:type]).to eq('message.produce_async') }
+    end
+
+    context 'when inline error occurs in librdkafka and we go beyond max wait on queue full' do
+      let(:errors) { [] }
+      let(:occurred) { [] }
+      let(:error) { errors.first }
+      let(:producer) do
+        build(
+          :slow_producer,
+          wait_on_queue_full: true,
+          wait_on_queue_full_timeout: 0.5
+        )
+      end
+
+      before do
+        producer.config.wait_on_queue_full = true
+
+        producer.monitor.subscribe('error.occurred') do |event|
+          occurred << event
+        end
+
+        begin
+          message = build(:valid_message)
+          5.times { producer.produce_async(message) }
+        rescue WaterDrop::Errors::ProduceError => e
+          errors << e
+        end
+      end
+
+      it { expect(errors).not_to be_empty }
+      it { expect(occurred.first.payload[:error].cause).to be_a(Rdkafka::RdkafkaError) }
+      it { expect(occurred.first.payload[:type]).to eq('message.produce_async') }
     end
   end
 

--- a/spec/support/factories/producer.rb
+++ b/spec/support/factories/producer.rb
@@ -7,6 +7,9 @@ FactoryBot.define do
     deliver { true }
     logger { Logger.new('/dev/null', level: Logger::DEBUG) }
     max_wait_timeout { 30 }
+    wait_on_queue_full { false }
+    wait_on_queue_full_timeout { 1.0 }
+
     kafka do
       {
         'bootstrap.servers': 'localhost:9092',
@@ -22,6 +25,8 @@ FactoryBot.define do
         config.logger = logger
         config.kafka = kafka
         config.max_wait_timeout = max_wait_timeout
+        config.wait_on_queue_full = wait_on_queue_full
+        config.wait_on_queue_full_timeout = wait_on_queue_full_timeout
       end
 
       instance.monitor.subscribe(::WaterDrop::Instrumentation::LoggerListener.new(logger))
@@ -31,6 +36,8 @@ FactoryBot.define do
   end
 
   factory :limited_producer, parent: :producer do
+    wait_on_queue_full_timeout { 15 }
+
     kafka do
       {
         'bootstrap.servers': 'localhost:9092',
@@ -43,6 +50,8 @@ FactoryBot.define do
   end
 
   factory :slow_producer, parent: :producer do
+    wait_on_queue_full_timeout { 2 }
+
     kafka do
       {
         'bootstrap.servers': 'localhost:9092',

--- a/spec/support/factories/producer.rb
+++ b/spec/support/factories/producer.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     logger { Logger.new('/dev/null', level: Logger::DEBUG) }
     max_wait_timeout { 30 }
     wait_on_queue_full { false }
-    wait_on_queue_full_timeout { 1.0 }
+    wait_timeout_on_queue_full { 1.0 }
 
     kafka do
       {
@@ -26,7 +26,7 @@ FactoryBot.define do
         config.kafka = kafka
         config.max_wait_timeout = max_wait_timeout
         config.wait_on_queue_full = wait_on_queue_full
-        config.wait_on_queue_full_timeout = wait_on_queue_full_timeout
+        config.wait_timeout_on_queue_full = wait_timeout_on_queue_full
       end
 
       instance.monitor.subscribe(::WaterDrop::Instrumentation::LoggerListener.new(logger))
@@ -36,7 +36,7 @@ FactoryBot.define do
   end
 
   factory :limited_producer, parent: :producer do
-    wait_on_queue_full_timeout { 15 }
+    wait_timeout_on_queue_full { 15 }
 
     kafka do
       {
@@ -50,7 +50,7 @@ FactoryBot.define do
   end
 
   factory :slow_producer, parent: :producer do
-    wait_on_queue_full_timeout { 2 }
+    wait_timeout_on_queue_full { 2 }
 
     kafka do
       {


### PR DESCRIPTION
This PR fixes few confusing inconsistencies:

- renames `wait_on_queue_full_timeout` to `wait_on_queue_full_backoff` to reflect what it does. 
- uses `wait_on_queue_full_timeout` correctly, that is to measure the total with retries
- fixes the `type` on error to indicate appropriate caller
- adds missing config validations

alongside:

close https://github.com/karafka/waterdrop/issues/351
close https://github.com/karafka/waterdrop/issues/335