### PR TITLE
Use concurrent-ruby thread-safe fixnum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WaterDrop changelog
 
+### 2.6.3 (Unreleased)
+- Use `Concurrent::AtomicFixnum` to track operations in progress to prevent potential race conditions on JRuby and TruffleRuby (not yet supported but this is for future usage).
+
 ### 2.6.2 (2023-06-21)
 - [Refactor] Introduce a counter-based locking approach to make sure, that we close the producer safely but at the same time not to limit messages production with producing lock.
 - [Refactor] Make private methods private.

--- a/lib/waterdrop.rb
+++ b/lib/waterdrop.rb
@@ -9,6 +9,7 @@
   securerandom
   karafka-core
   pathname
+  concurrent/atomic/atomic_fixnum
 ].each { |lib| require lib }
 
 # WaterDrop library

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.6.2'
+  VERSION = '2.6.3'
 end


### PR DESCRIPTION
While I was not able to prove with specs nor benchmarks that this affects CRuby - replacing this just to be sure plus to make sure this can operate well in other Ruby implementations for future compatibility. Concurrent is a dependency of karafka-core, hence no gemspec changes.
