### PR TITLE
allow for disabling of extensive messages logging in the logger listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WaterDrop changelog
 
+### 2.6.6 (Unreleased)
+- [Improvement] Provide `log_messages` option to `LoggerListener` so the extensive messages data logging can disabled.
+
 ### 2.6.5 (2023-07-22)
 - [Fix] Add cause to the errors that are passed into instrumentation (konalegi)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.6.5)
+    waterdrop (2.6.6)
       karafka-core (>= 2.1.1, < 3.0.0)
       zeitwerk (~> 2.3)
 

--- a/README.md
+++ b/README.md
@@ -339,6 +339,35 @@ Karafka [Web UI](https://karafka.io/docs/Web-UI-Getting-Started/) is a user inte
 
 ![Example producer errors in Karafka Web-UI](https://raw.githubusercontent.com/karafka/misc/master/printscreens/web-ui/errors-producer.png)
 
+### Logger Listener
+
+WaterDrop comes equipped with a `LoggerListener`, a useful feature designed to facilitate the reporting of WaterDrop's operational details directly into the assigned logger. The `LoggerListener` provides a convenient way of tracking the events and operations that occur during the usage of WaterDrop, enhancing transparency and making debugging and issue tracking easier.
+
+However, it's important to note that this Logger Listener is not subscribed by default. This means that WaterDrop does not automatically send operation data to your logger out of the box. This design choice has been made to give users greater flexibility and control over their logging configuration.
+
+To use this functionality, you need to manually subscribe the `LoggerListener` to WaterDrop instrumentation. Below, you will find an example demonstrating how to perform this subscription.
+
+```ruby
+LOGGER = Logger.new($stdout)
+
+producer = WaterDrop::Producer.new do |config|
+  config.kafka = { 'bootstrap.servers': 'localhost:9092' }
+  config.logger = LOGGER
+end
+
+producer.monitor.subscribe(
+  WaterDrop::Instrumentation::LoggerListener.new(
+    # You can use a different logger than the one assigned to WaterDrop if you want
+    producer.config.logger,
+    # If this is set to false, the produced messages details will not be sent to logs
+    # You may set it to false if you find the level of reporting in the debug too extensive
+    log_messages: true
+  )
+)
+
+producer.produce_sync(topic: 'my.topic', payload: 'my.message')
+```
+
 ### Usage statistics
 
 WaterDrop is configured to emit internal `librdkafka` metrics every five seconds. You can change this by setting the `kafka` `statistics.interval.ms` configuration property to a value greater of equal `0`. Emitted statistics are available after subscribing to the `statistics.emitted` publisher event. If set to `0`, metrics will not be published.

--- a/lib/waterdrop/instrumentation/logger_listener.rb
+++ b/lib/waterdrop/instrumentation/logger_listener.rb
@@ -9,8 +9,15 @@ module WaterDrop
     #   as well as we can use it standalone
     class LoggerListener
       # @param logger [Object] logger we want to use
-      def initialize(logger)
+      # @param log_messages [Boolean] should we report in debug the messages.
+      #   This can be extensive, especially when producing a lot of messages. We provide this
+      #   despite the fact that we only report payloads in debug, because Rails by default operates
+      #   with debug level. This means, that when working with Rails in development, every single
+      #   payload dispatched will go to logs. In majority of the cases this is extensive and simply
+      #   floods the end user.
+      def initialize(logger, log_messages: true)
         @logger = logger
+        @log_messages = log_messages
       end
 
       # @param event [Dry::Events::Event] event that happened with the details
@@ -18,6 +25,9 @@ module WaterDrop
         message = event[:message]
 
         info(event, "Async producing of a message to '#{message[:topic]}' topic")
+
+        return unless log_messages?
+
         debug(event, message)
       end
 
@@ -26,6 +36,9 @@ module WaterDrop
         message = event[:message]
 
         info(event, "Sync producing of a message to '#{message[:topic]}' topic")
+
+        return unless log_messages?
+
         debug(event, message)
       end
 
@@ -35,6 +48,9 @@ module WaterDrop
         topics_count = messages.map { |message| "'#{message[:topic]}'" }.uniq.count
 
         info(event, "Async producing of #{messages.size} messages to #{topics_count} topics")
+
+        return unless log_messages?
+
         debug(event, messages)
       end
 
@@ -44,6 +60,9 @@ module WaterDrop
         topics_count = messages.map { |message| "'#{message[:topic]}'" }.uniq.count
 
         info(event, "Sync producing of #{messages.size} messages to #{topics_count} topics")
+
+        return unless log_messages?
+
         debug(event, messages)
       end
 
@@ -52,6 +71,9 @@ module WaterDrop
         message = event[:message]
 
         info(event, "Buffering of a message to '#{message[:topic]}' topic")
+
+        return unless log_messages?
+
         debug(event, [message])
       end
 
@@ -60,6 +82,9 @@ module WaterDrop
         messages = event[:messages]
 
         info(event, "Buffering of #{messages.size} messages")
+
+        return unless log_messages?
+
         debug(event, [messages, messages.size])
       end
 
@@ -68,6 +93,9 @@ module WaterDrop
         messages = event[:messages]
 
         info(event, "Async flushing of #{messages.size} messages from the buffer")
+
+        return unless log_messages?
+
         debug(event, messages)
       end
 
@@ -76,6 +104,9 @@ module WaterDrop
         messages = event[:messages]
 
         info(event, "Sync flushing of #{messages.size} messages from the buffer")
+
+        return unless log_messages?
+
         debug(event, messages)
       end
 
@@ -93,6 +124,11 @@ module WaterDrop
       end
 
       private
+
+      # @return [Boolean] should we report the messages details in the debug mode.
+      def log_messages?
+        @log_messages
+      end
 
       # @param event [Dry::Events::Event] event that happened with the details
       # @param log_message [String] message we want to publish

--- a/lib/waterdrop/instrumentation/logger_listener.rb
+++ b/lib/waterdrop/instrumentation/logger_listener.rb
@@ -9,7 +9,9 @@ module WaterDrop
     #   as well as we can use it standalone
     class LoggerListener
       # @param logger [Object] logger we want to use
-      # @param log_messages [Boolean] should we report in debug the messages.
+      # @param log_messages [Boolean] Should we report the messages content (payload and metadata)
+      #   with each message operation.
+      #
       #   This can be extensive, especially when producing a lot of messages. We provide this
       #   despite the fact that we only report payloads in debug, because Rails by default operates
       #   with debug level. This means, that when working with Rails in development, every single

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.6.5'
+  VERSION = '2.6.6'
 end

--- a/spec/lib/waterdrop/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/waterdrop/instrumentation/logger_listener_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe_current do
     it { expect(logged_data[1]).to include(producer.id) }
     it { expect(logged_data[1]).to include('DEBUG') }
     it { expect(logged_data[1]).to include(message.to_s) }
+
+    context 'when we do not want to log messages content' do
+      let(:listener) { described_class.new(logger, log_messages: false) }
+
+      it { expect(logged_data[0]).to include(producer.id) }
+      it { expect(logged_data[0]).to include('INFO') }
+      it { expect(logged_data[0]).to include('Async producing of a message to') }
+      it { expect(logged_data[0]).to include(message[:topic]) }
+      it { expect(logged_data[1]).to eq(nil) }
+    end
   end
 
   describe '#on_message_produced_sync' do
@@ -45,6 +55,16 @@ RSpec.describe_current do
     it { expect(logged_data[1]).to include(producer.id) }
     it { expect(logged_data[1]).to include('DEBUG') }
     it { expect(logged_data[1]).to include(message.to_s) }
+
+    context 'when we do not want to log messages content' do
+      let(:listener) { described_class.new(logger, log_messages: false) }
+
+      it { expect(logged_data[0]).to include(producer.id) }
+      it { expect(logged_data[0]).to include('INFO') }
+      it { expect(logged_data[0]).to include('Sync producing of a message to') }
+      it { expect(logged_data[0]).to include(message[:topic]) }
+      it { expect(logged_data[1]).to eq(nil) }
+    end
   end
 
   describe '#on_messages_produced_async' do
@@ -56,6 +76,15 @@ RSpec.describe_current do
     it { expect(logged_data[1]).to include(producer.id) }
     it { expect(logged_data[1]).to include('DEBUG') }
     it { expect(logged_data[1]).to include(message.to_s) }
+
+    context 'when we do not want to log messages content' do
+      let(:listener) { described_class.new(logger, log_messages: false) }
+
+      it { expect(logged_data[0]).to include(producer.id) }
+      it { expect(logged_data[0]).to include('INFO') }
+      it { expect(logged_data[0]).to include('Async producing of 2 messages to 2 topics') }
+      it { expect(logged_data[1]).to eq(nil) }
+    end
   end
 
   describe '#on_messages_produced_sync' do
@@ -67,6 +96,15 @@ RSpec.describe_current do
     it { expect(logged_data[1]).to include(producer.id) }
     it { expect(logged_data[1]).to include('DEBUG') }
     it { expect(logged_data[1]).to include(message.to_s) }
+
+    context 'when we do not want to log messages content' do
+      let(:listener) { described_class.new(logger, log_messages: false) }
+
+      it { expect(logged_data[0]).to include(producer.id) }
+      it { expect(logged_data[0]).to include('INFO') }
+      it { expect(logged_data[0]).to include('Sync producing of 2 messages to 2 topics') }
+      it { expect(logged_data[1]).to eq(nil) }
+    end
   end
 
   describe '#on_message_buffered' do
@@ -79,6 +117,16 @@ RSpec.describe_current do
     it { expect(logged_data[1]).to include(producer.id) }
     it { expect(logged_data[1]).to include('DEBUG') }
     it { expect(logged_data[1]).to include(message.to_s) }
+
+    context 'when we do not want to log messages content' do
+      let(:listener) { described_class.new(logger, log_messages: false) }
+
+      it { expect(logged_data[0]).to include(producer.id) }
+      it { expect(logged_data[0]).to include('INFO') }
+      it { expect(logged_data[0]).to include('Buffering of a message to ') }
+      it { expect(logged_data[0]).to include(message[:topic]) }
+      it { expect(logged_data[1]).to eq(nil) }
+    end
   end
 
   describe '#on_messages_buffered' do
@@ -90,6 +138,15 @@ RSpec.describe_current do
     it { expect(logged_data[1]).to include(producer.id) }
     it { expect(logged_data[1]).to include('DEBUG') }
     it { expect(logged_data[1]).to include(message.to_s) }
+
+    context 'when we do not want to log messages content' do
+      let(:listener) { described_class.new(logger, log_messages: false) }
+
+      it { expect(logged_data[0]).to include(producer.id) }
+      it { expect(logged_data[0]).to include('INFO') }
+      it { expect(logged_data[0]).to include('Buffering of 2 messages ') }
+      it { expect(logged_data[1]).to eq(nil) }
+    end
   end
 
   describe '#on_buffer_flushed_async' do
@@ -103,6 +160,15 @@ RSpec.describe_current do
     it { expect(logged_data[1]).to include(message.to_s) }
     it { expect(logged_data[1]).to include(messages[0].to_s) }
     it { expect(logged_data[1]).to include(messages[1].to_s) }
+
+    context 'when we do not want to log messages content' do
+      let(:listener) { described_class.new(logger, log_messages: false) }
+
+      it { expect(logged_data[0]).to include(producer.id) }
+      it { expect(logged_data[0]).to include('INFO') }
+      it { expect(logged_data[0]).to include('Async flushing of 2 messages from the buffer') }
+      it { expect(logged_data[1]).to eq(nil) }
+    end
   end
 
   describe '#on_buffer_flushed_sync' do
@@ -115,6 +181,15 @@ RSpec.describe_current do
     it { expect(logged_data[1]).to include('DEBUG') }
     it { expect(logged_data[1]).to include(messages[0].to_s) }
     it { expect(logged_data[1]).to include(messages[1].to_s) }
+
+    context 'when we do not want to log messages content' do
+      let(:listener) { described_class.new(logger, log_messages: false) }
+
+      it { expect(logged_data[0]).to include(producer.id) }
+      it { expect(logged_data[0]).to include('INFO') }
+      it { expect(logged_data[0]).to include('Sync flushing of 2 messages from the buffer') }
+      it { expect(logged_data[1]).to eq(nil) }
+    end
   end
 
   describe '#on_producer_closed' do


### PR DESCRIPTION
Mitigates the issue when especially in Rails the logger debug level reports extensively whole messages content.

close https://github.com/karafka/waterdrop/issues/375