### PR TITLE
v2.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # WaterDrop changelog
 
-## 2.7.0 (Unreleased)
+## 2.6.8 (2023-10-20)
 - **[Feature]** Introduce transactions support.
 - [Improvement] Expand `LoggerListener` to inform about transactions (info level).
 - [Improvement] Allow waterdrop to use topic as a symbol or a string.
@@ -8,10 +8,6 @@
 - [Improvement] Provide `#close!` that will force producer close even with outgoing data after the ma wait timeout.
 - [Improvement] Provide `#purge` that will purge any outgoing data and data from the internal queues (both WaterDrop and librdkafka).
 - [Fix] Fix the `librdkafka.dispatch_error` error dispatch for errors with negative code.
-
-### Upgrade Notes
-
-There are no breaking changes in this release. However, if you upgrade WaterDrop in Karafka **and** choose to use transactions, Karafka Web UI may not support it. Web UI will support transactional producers starting from `0.7.7`.
 
 ## 2.6.7 (2023-09-01)
 - [Improvement] early flush data from `librdkafka` internal buffer before closing.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.7.0)
+    waterdrop (2.6.8)
       karafka-core (>= 2.2.3, < 3.0.0)
       zeitwerk (~> 2.3)
 

--- a/lib/waterdrop/clients/buffered.rb
+++ b/lib/waterdrop/clients/buffered.rb
@@ -73,12 +73,12 @@ module WaterDrop
 
         raise
       ensure
-        return result unless @transaction_mutex.owned?
-
-        @transaction_topics.clear
-        @transaction_messages.clear
-        @transaction_active = false
-        @transaction_mutex.unlock
+        if @transaction_mutex.owned?
+          @transaction_topics.clear
+          @transaction_messages.clear
+          @transaction_active = false
+          @transaction_mutex.unlock
+        end
       end
 
       # Returns messages produced to a given topic

--- a/lib/waterdrop/clients/dummy.rb
+++ b/lib/waterdrop/clients/dummy.rb
@@ -25,6 +25,26 @@ module WaterDrop
         true
       end
 
+      # Yields the code pretending it is in a transaction
+      # Supports our aborting transaction flow
+      def transaction
+        result = nil
+        commit = false
+
+        catch(:abort) do
+          result = yield
+          commit = true
+        end
+
+        commit || raise(WaterDrop::Errors::AbortTransaction)
+
+        result
+      rescue StandardError => e
+        return if e.is_a?(WaterDrop::Errors::AbortTransaction)
+
+        raise
+      end
+
       # @param _args [Object] anything really, this dummy is suppose to support anything
       # @return [self] returns self for chaining cases
       def method_missing(*_args)

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.7.0'
+  VERSION = '2.6.8'
 end

--- a/spec/lib/waterdrop/clients/buffered_spec.rb
+++ b/spec/lib/waterdrop/clients/buffered_spec.rb
@@ -64,4 +64,84 @@ RSpec.describe_current do
     it { expect(client.messages).to be_empty }
     it { expect(client.messages_for('foo')).to be_empty }
   end
+
+  describe '#transaction' do
+    context 'when no error and no abort' do
+      it 'expect to return the block value' do
+        expect(client.transaction { 1 }).to eq(1)
+      end
+    end
+
+    context 'when running transaction with production of messages' do
+      it 'expect to add them to the buffers' do
+        client.transaction do
+          client.produce(topic: 'test', payload: 'test')
+          client.produce(topic: 'test', payload: 'test')
+        end
+
+        expect(client.messages.size).to eq(5)
+        expect(client.messages_for('test').size).to eq(2)
+      end
+    end
+
+    context 'when abort occurs' do
+      it 'expect not to raise error' do
+        expect do
+          client.transaction { throw(:abort) }
+        end.not_to raise_error
+      end
+
+      it 'expect not to contain messages from the aborted transaction' do
+        client.transaction do
+          client.produce(topic: 'test', payload: 'test')
+          throw(:abort)
+        end
+
+        expect(client.messages.size).to eq(3)
+        expect(client.messages_for('test')).to be_empty
+      end
+    end
+
+    context 'when WaterDrop::Errors::AbortTransaction error occurs' do
+      it 'expect not to raise error' do
+        expect do
+          client.transaction { raise(WaterDrop::Errors::AbortTransaction) }
+        end.not_to raise_error
+      end
+    end
+
+    context 'when different error occurs' do
+      it 'expect to raise error' do
+        expect do
+          client.transaction { raise(StandardError) }
+        end.to raise_error(StandardError)
+      end
+
+      it 'expect not to contain messages from the aborted transaction' do
+        expect do
+          client.transaction do
+            client.produce(topic: 'test', payload: 'test')
+
+            raise StandardError
+          end
+        end.to raise_error(StandardError)
+
+        expect(client.messages.size).to eq(3)
+        expect(client.messages_for('test')).to be_empty
+      end
+    end
+
+    context 'when running a nested transaction' do
+      it 'expect to work ok' do
+        result = client.transaction do
+          client.transaction do
+            client.produce(topic: '1', payload: '2')
+            2
+          end
+        end
+
+        expect(result).to eq(2)
+      end
+    end
+  end
 end

--- a/spec/lib/waterdrop/clients/dummy_spec.rb
+++ b/spec/lib/waterdrop/clients/dummy_spec.rb
@@ -24,4 +24,49 @@ RSpec.describe_current do
   describe '#respond_to?' do
     it { expect(client.respond_to?(:test)).to eq(true) }
   end
+
+  describe '#transaction' do
+    context 'when no error and no abort' do
+      it 'expect to return the block value' do
+        expect(client.transaction { 1 }).to eq(1)
+      end
+    end
+
+    context 'when abort occurs' do
+      it 'expect not to raise error' do
+        expect do
+          client.transaction { throw(:abort) }
+        end.not_to raise_error
+      end
+    end
+
+    context 'when WaterDrop::Errors::AbortTransaction error occurs' do
+      it 'expect not to raise error' do
+        expect do
+          client.transaction { raise(WaterDrop::Errors::AbortTransaction) }
+        end.not_to raise_error
+      end
+    end
+
+    context 'when different error occurs' do
+      it 'expect to raise error' do
+        expect do
+          client.transaction { raise(StandardError) }
+        end.to raise_error(StandardError)
+      end
+    end
+
+    context 'when running a nested transaction' do
+      it 'expect to work ok' do
+        result = client.transaction do
+          client.transaction do
+            client.produce(topic: '1', payload: '2')
+            2
+          end
+        end
+
+        expect(result).to eq(2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
not bumping to 2.7.0 since no breaking changes and waterdrop will work out of the box with karafka-web even when in transactional mode due to recent changes.