### PR TITLE
handle critical errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # WaterDrop changelog
 
+## 2.6.9 (Unreleased)
+- [Improvement] Introduce a `transaction.finished` event to indicate that transaction has finished whether it was aborted or committed.
+- [Improvement] Use `transaction.committed` event to indicate that transaction has been committed.
+
 ## 2.6.8 (2023-10-20)
 - **[Feature]** Introduce transactions support.
 - [Improvement] Expand `LoggerListener` to inform about transactions (info level).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.6.8)
+    waterdrop (2.6.9)
       karafka-core (>= 2.2.3, < 3.0.0)
       zeitwerk (~> 2.3)
 

--- a/lib/waterdrop/instrumentation/logger_listener.rb
+++ b/lib/waterdrop/instrumentation/logger_listener.rb
@@ -145,6 +145,11 @@ module WaterDrop
         info(event, 'Committing transaction')
       end
 
+      # @param event [Dry::Events::Event] event that happened with the details
+      def on_transaction_finished(event)
+        info(event, 'Processing transaction')
+      end
+
       private
 
       # @return [Boolean] should we report the messages details in the debug mode.

--- a/lib/waterdrop/instrumentation/notifications.rb
+++ b/lib/waterdrop/instrumentation/notifications.rb
@@ -21,6 +21,7 @@ module WaterDrop
         transaction.started
         transaction.committed
         transaction.aborted
+        transaction.finished
 
         buffer.flushed_async
         buffer.flushed_sync

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.6.8'
+  VERSION = '2.6.9'
 end


### PR DESCRIPTION
This PR fixes the below issue and also makes sure we abort transaction on all errors including criticals.

close https://github.com/karafka/waterdrop/issues/399