### PR TITLE
align transactional api

### DIFF
--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -29,10 +29,8 @@ en:
 
     transactional_offset:
       consumer_format: 'must respond to #consumer_group_metadata_pointer method'
-      topic_format: must be a non-empty string
+      message_format: 'must respond to #topic, #partition and #offset'
       missing: must be present
-      partition_format: must be an integer greater or equal to -1
-      offset_format: must be an integer greater or equal to -1
       offset_metadata_format: must be string or nil
 
     test:

--- a/lib/waterdrop/contracts/transactional_offset.rb
+++ b/lib/waterdrop/contracts/transactional_offset.rb
@@ -14,9 +14,7 @@ module WaterDrop
       end
 
       required(:consumer) { |val| val.respond_to?(:consumer_group_metadata_pointer) }
-      required(:topic) { |val| val.is_a?(String) && !val.empty? }
-      required(:partition) { |val| val.is_a?(Integer) && val >= 0 }
-      required(:offset) { |val| val.is_a?(Integer) && val >= 0 }
+      required(:message) { |val| val.respond_to?(:topic) && val.respond_to?(:partition) }
       required(:offset_metadata) { |val| val.is_a?(String) || val.nil? }
     end
   end

--- a/lib/waterdrop/instrumentation/logger_listener.rb
+++ b/lib/waterdrop/instrumentation/logger_listener.rb
@@ -146,12 +146,17 @@ module WaterDrop
       end
 
       # @param event [Dry::Events::Event] event that happened with the details
-      def on_transaction_offset_stored(event)
-        topic = event[:topic]
-        partition = event[:partition]
-        offset = event[:offset]
+      def on_transaction_marked_as_consumed(event)
+        message = event[:message]
+        topic = message.topic
+        partition = message.partition
+        offset = message.offset
+        loc = "#{topic}/#{partition}"
 
-        info(event, "Storing offset #{offset} for topic #{topic}/#{partition} in the transaction")
+        info(
+          event,
+          "Marking message with offset #{offset} for topic #{loc} as consumed in a transaction"
+        )
       end
 
       # @param event [Dry::Events::Event] event that happened with the details

--- a/lib/waterdrop/instrumentation/notifications.rb
+++ b/lib/waterdrop/instrumentation/notifications.rb
@@ -22,7 +22,7 @@ module WaterDrop
         transaction.started
         transaction.committed
         transaction.aborted
-        transaction.offset_stored
+        transaction.marked_as_consumed
         transaction.finished
 
         buffer.flushed_async

--- a/spec/lib/waterdrop/clients/buffered_spec.rb
+++ b/spec/lib/waterdrop/clients/buffered_spec.rb
@@ -181,19 +181,22 @@ RSpec.describe_current do
     end
 
     context 'when we try to store offset without a transaction' do
+      let(:message) { OpenStruct.new(topic: rand.to_s, partition: 0, offset: 10) }
+
       it 'expect to raise an error' do
-        expect { producer.transactional_store_offset(nil, 'topic', 0, 0) }
+        expect { producer.transaction_mark_as_consumed(nil, message) }
           .to raise_error(WaterDrop::Errors::TransactionRequiredError)
       end
     end
 
     context 'when trying to store offset with transaction' do
       let(:consumer) { OpenStruct.new(consumer_group_metadata_pointer: nil) }
+      let(:message) { OpenStruct.new(topic: rand.to_s, partition: 0, offset: 10) }
 
       it do
         expect do
           producer.transaction do
-            producer.transactional_store_offset(consumer, 'topic', 0, 0)
+            producer.transaction_mark_as_consumed(consumer, message)
           end
         end.not_to raise_error
       end

--- a/spec/lib/waterdrop/contracts/transactional_offset_spec.rb
+++ b/spec/lib/waterdrop/contracts/transactional_offset_spec.rb
@@ -7,13 +7,12 @@ RSpec.describe_current do
   let(:topic) { 'test_topic' }
   let(:partition) { 0 }
   let(:offset) { 10 }
+  let(:message) { OpenStruct.new(topic: topic, partition: partition, offset: offset) }
   let(:offset_metadata) { 'metadata' }
   let(:input) do
     {
       consumer: consumer,
-      topic: topic,
-      partition: partition,
-      offset: offset,
+      message: message,
       offset_metadata: offset_metadata
     }
   end
@@ -28,43 +27,9 @@ RSpec.describe_current do
     it { expect(contract_result).not_to be_success }
   end
 
-  context 'when topic is invalid' do
-    context 'when topic is empty' do
-      let(:topic) { '' }
-
-      it { expect(contract_result).not_to be_success }
-    end
-
-    context 'when topic is not a string' do
-      let(:topic) { 123 }
-
-      it { expect(contract_result).not_to be_success }
-    end
-  end
-
-  context 'when partition is invalid' do
-    context 'when partition is negative' do
-      let(:partition) { -1 }
-
-      it { expect(contract_result).not_to be_success }
-    end
-
-    context 'when partition is not an integer' do
-      let(:partition) { 'not_an_integer' }
-
-      it { expect(contract_result).not_to be_success }
-    end
-  end
-
-  context 'when offset is invalid' do
-    context 'when offset is negative' do
-      let(:offset) { -10 }
-
-      it { expect(contract_result).not_to be_success }
-    end
-
-    context 'when offset is not an integer' do
-      let(:offset) { 'not_an_integer' }
+  context 'when message is invalid' do
+    context 'when message is a string' do
+      let(:message) { 'test' }
 
       it { expect(contract_result).not_to be_success }
     end

--- a/spec/lib/waterdrop/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/waterdrop/instrumentation/logger_listener_spec.rb
@@ -244,17 +244,19 @@ RSpec.describe_current do
     it { expect(logged_data[0]).to include('Committing transaction') }
   end
 
-  describe '#on_transaction_offset_stored' do
+  describe '#on_transaction_marked_as_consumed' do
     before do
-      details[:topic] = rand.to_s
-      details[:partition] = 0
-      details[:offset] = 100
+      details[:message] = OpenStruct.new(
+        topic: rand.to_s,
+        partition: 0,
+        offset: 100
+      )
 
-      listener.on_transaction_offset_stored(event)
+      listener.on_transaction_marked_as_consumed(event)
     end
 
     it { expect(logged_data[0]).to include(producer.id) }
     it { expect(logged_data[0]).to include('INFO') }
-    it { expect(logged_data[0]).to include('Storing offset') }
+    it { expect(logged_data[0]).to include('Marking message') }
   end
 end


### PR DESCRIPTION
While working on it during the weekend in karafka I noticed that this API actually resembles more rdkafka API rather than high-levle karafka API. This changes that.

Not a breaking change since transcational exactly once semantics API was not released yet. That way our transactional and regular marking as consumed in karafka can have aligned API expectation.