### PR TITLE
upgrade warnings from rdkafka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This release contains **BREAKING** changes. Make sure to read and apply upgrade 
 - **[Breaking]** Drop Ruby `2.7` support.
 - **[Breaking]** Change default timeouts so final delivery `message.timeout.ms` is less that `max_wait_time` so we do not end up with not final verdict.
 - **[Breaking]** Update all the time related configuration settings to be in `ms` and not mixed.
+- **[Breaking]** Remove no longer needed `wait_timeout` configuration option.
 - [Enhancement] Introduce `instrument_on_wait_queue_full` flag (defaults to `true`) to be able to configure whether non critical (retryable) queue full errors should be instrumented in the error pipeline. Useful when building high-performance pipes with WaterDrop queue retry backoff as a throttler.
 
 ### Upgrade Notes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.7.0.alpha1)
+    waterdrop (2.7.0.alpha2)
       karafka-core (>= 2.4.0.alpha1, < 3.0.0)
       zeitwerk (~> 2.3)
 

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -6,7 +6,6 @@ en:
       deliver_format: must be boolean
       id_format: must be a non-empty string
       max_payload_size_format: must be an integer that is equal or bigger than 1
-      wait_timeout_format: must be a numeric that is bigger than 0
       max_wait_timeout_format: must be an integer that is equal or bigger than 0
       kafka_format: must be a hash with symbol based keys
       kafka_key_must_be_a_symbol: All keys under the kafka settings scope need to be symbols

--- a/lib/waterdrop/config.rb
+++ b/lib/waterdrop/config.rb
@@ -51,10 +51,6 @@ module WaterDrop
     # option [Integer] Wait that long for the delivery report or raise an error if this takes
     #   longer than the timeout ms.
     setting :max_wait_timeout, default: 60_000
-    # option [Numeric] how long should we wait between re-checks on the availability of the
-    #   delivery report. In a really robust systems, this describes the min-delivery time
-    #   for a single sync message when produced in isolation
-    setting :wait_timeout, default: 5 # 5 milliseconds
     # option [Boolean] should we upon detecting full librdkafka queue backoff and retry or should
     #   we raise an exception.
     #   When this is set to `true`, upon full queue, we won't raise an error. There will be error

--- a/lib/waterdrop/contracts/config.rb
+++ b/lib/waterdrop/contracts/config.rb
@@ -17,7 +17,6 @@ module WaterDrop
       required(:deliver) { |val| [true, false].include?(val) }
       required(:max_payload_size) { |val| val.is_a?(Integer) && val >= 1 }
       required(:max_wait_timeout) { |val| val.is_a?(Numeric) && val >= 0 }
-      required(:wait_timeout) { |val| val.is_a?(Numeric) && val.positive? }
       required(:kafka) { |val| val.is_a?(Hash) && !val.empty? }
       required(:wait_on_queue_full) { |val| [true, false].include?(val) }
       required(:wait_backoff_on_queue_full) { |val| val.is_a?(Numeric) && val >= 0 }

--- a/lib/waterdrop/producer.rb
+++ b/lib/waterdrop/producer.rb
@@ -250,8 +250,7 @@ module WaterDrop
     def wait(handler)
       handler.wait(
         # rdkafka max_wait_timeout is in seconds and we use ms
-        max_wait_timeout: @config.max_wait_timeout / 1_000.0,
-        wait_timeout: @config.wait_timeout / 1_000.0
+        max_wait_timeout: @config.max_wait_timeout / 1_000.0
       )
     end
 

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.7.0.alpha1'
+  VERSION = '2.7.0.alpha2'
 end

--- a/spec/lib/waterdrop/contracts/config_spec.rb
+++ b/spec/lib/waterdrop/contracts/config_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe_current do
       deliver: false,
       max_payload_size: 1024 * 1024,
       max_wait_timeout: 1,
-      wait_timeout: 0.1,
       wait_on_queue_full: true,
       wait_backoff_on_queue_full: 1,
       wait_timeout_on_queue_full: 10,
@@ -184,53 +183,6 @@ RSpec.describe_current do
 
   context 'when max_wait_timeout is positive float' do
     before { config[:max_wait_timeout] = 1.1 }
-
-    it { expect(contract_result).to be_success }
-  end
-
-  context 'when wait_timeout is missing' do
-    before { config.delete(:wait_timeout) }
-
-    it { expect(contract_result).not_to be_success }
-    it { expect(contract_errors[:wait_timeout]).not_to be_empty }
-  end
-
-  context 'when wait_timeout is nil' do
-    before { config[:wait_timeout] = nil }
-
-    it { expect(contract_result).not_to be_success }
-    it { expect(contract_errors[:wait_timeout]).not_to be_empty }
-  end
-
-  context 'when wait_timeout is a negative int' do
-    before { config[:wait_timeout] = -1 }
-
-    it { expect(contract_result).not_to be_success }
-    it { expect(contract_errors[:wait_timeout]).not_to be_empty }
-  end
-
-  context 'when wait_timeout is a negative float' do
-    before { config[:wait_timeout] = -0.1 }
-
-    it { expect(contract_result).not_to be_success }
-    it { expect(contract_errors[:wait_timeout]).not_to be_empty }
-  end
-
-  context 'when wait_timeout is 0' do
-    before { config[:wait_timeout] = 0 }
-
-    it { expect(contract_result).not_to be_success }
-    it { expect(contract_errors[:wait_timeout]).not_to be_empty }
-  end
-
-  context 'when wait_timeout is positive int' do
-    before { config[:wait_timeout] = 1 }
-
-    it { expect(contract_result).to be_success }
-  end
-
-  context 'when wait_timeout is positive float' do
-    before { config[:wait_timeout] = 1.1 }
 
     it { expect(contract_result).to be_success }
   end


### PR DESCRIPTION
This PR removes the warnings coming from changes in rdkafka-ruby and bumps alpha release.