### PR TITLE
Treat the queue size as a gauge rather than a cumulative stat

### DIFF
--- a/lib/waterdrop/instrumentation/vendors/datadog/metrics_listener.rb
+++ b/lib/waterdrop/instrumentation/vendors/datadog/metrics_listener.rb
@@ -36,7 +36,7 @@ module WaterDrop
           setting :rd_kafka_metrics, default: [
             # Client metrics
             RdKafkaMetric.new(:count, :root, 'calls', 'tx_d'),
-            RdKafkaMetric.new(:histogram, :root, 'queue.size', 'msg_cnt_d'),
+            RdKafkaMetric.new(:histogram, :root, 'queue.size', 'msg_cnt'),
 
             # Broker metrics
             RdKafkaMetric.new(:count, :brokers, 'deliver.attempts', 'txretries_d'),


### PR DESCRIPTION
According to rdkafka documentation (https://karafka.io/docs/Librdkafka-Statistics/#brokers) this is already a gauge, and doesn't need to be diffed like the cumulative stats do. This is supported by our observations--in our application this metric is frequently negative.