### PR TITLE
Add topic scope to report_metric

### DIFF
--- a/lib/waterdrop/instrumentation/vendors/datadog/metrics_listener.rb
+++ b/lib/waterdrop/instrumentation/vendors/datadog/metrics_listener.rb
@@ -199,6 +199,16 @@ module WaterDrop
                   tags: default_tags + ["broker:#{broker_statistics['nodename']}"]
                 )
               end
+            when :topics
+              statistics.fetch('topics').each_value do |topic_statistics|
+
+                public_send(
+                  metric.type,
+                  metric.name,
+                  topic_statistics.dig(*metric.key_location),
+                  tags: default_tags + ["topic:#{topic_statistics['topic']}"]
+                )
+              end
             else
               raise ArgumentError, metric.scope
             end


### PR DESCRIPTION
### Summary:
Librdkafka emits topic level stats like so:
```
{
  "name": "rdkafka#producer-1",
  "client_id": "rdkafka",
  "ts": 5016483227792,
  "brokers": {},
  "topics": {
    "test": {
      "topic": "test",
      "batchsize": {},
      "batchcnt": {},
      "partitions": {}
      }
    }
  },
}
```
This update allows users to subscribe to topic level stats as a metric with:
`RdKafkaMetric.new(:gauge, :topics, 'topics.batchcnt.avg', %w[batchcnt avg])`

Related issue: https://github.com/karafka/waterdrop/issues/495
