### PR TITLE
limit ms logger resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # WaterDrop changelog
 
 ## 2.7.4 (Unreleased)
+- [Maintenance] Lower the precision reporting to 100 microseconds in the logger listener.
 - [Change] Require 'karafka-core' `>= 2.4.3`
 
 ## 2.7.3 (2024-06-09)

--- a/lib/waterdrop/instrumentation/logger_listener.rb
+++ b/lib/waterdrop/instrumentation/logger_listener.rb
@@ -193,7 +193,8 @@ module WaterDrop
       # @param log_message [String] message we want to publish
       def info(event, log_message)
         if event.payload.key?(:time)
-          @logger.info("[#{event[:producer_id]}] #{log_message} took #{event[:time]} ms")
+          time = event[:time].round(2)
+          @logger.info("[#{event[:producer_id]}] #{log_message} took #{time} ms")
         else
           @logger.info("[#{event[:producer_id]}] #{log_message}")
         end

--- a/lib/waterdrop/instrumentation/logger_listener.rb
+++ b/lib/waterdrop/instrumentation/logger_listener.rb
@@ -193,8 +193,7 @@ module WaterDrop
       # @param log_message [String] message we want to publish
       def info(event, log_message)
         if event.payload.key?(:time)
-          time = event[:time].round(2)
-          @logger.info("[#{event[:producer_id]}] #{log_message} took #{time} ms")
+          @logger.info("[#{event[:producer_id]}] #{log_message} took #{event[:time].round(2)} ms")
         else
           @logger.info("[#{event[:producer_id]}] #{log_message}")
         end


### PR DESCRIPTION
it was pointed to me that having a super-microsecond precision makes no sense and I agree.

before:
```
[waterdrop-915b81c89ffe] Async producing of 1 messages to 1 topics took 0.09454702043533325 ms
```

after:
```
[waterdrop-915b81c89ffe] Async producing of 1 messages to 1 topics took 0.09 ms
```

the same will be done in karafka.