### PR TITLE
Require ruby 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 This release contains **BREAKING** changes. Make sure to read and apply upgrade notes.
 
+- **[Breaking]** Require Ruby `3.1+`.
 - **[Breaking]** Remove ability to abort transactions using `throw(:abort)`. Please use `raise WaterDrop::Errors::AbortTransaction`.
 - **[Breaking]** Disallow (similar to ActiveRecord) exiting transactions with `return`, `break` or `throw`.
 - **[Breaking]** License changed from MIT to LGPL with an additional commercial option. Note: there is no commercial code in this repository. The commercial license is available for companies unable to use LGPL-licensed software for legal reasons.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     waterdrop (2.8.0)
       karafka-core (>= 2.4.3, < 3.0.0)
-      karafka-rdkafka (>= 0.15.1)
+      karafka-rdkafka (>= 0.17.5)
       zeitwerk (~> 2.3)
 
 GEM
@@ -26,16 +26,16 @@ GEM
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     diff-lcs (1.5.1)
-    docile (1.4.0)
+    docile (1.4.1)
     drb (2.2.1)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     ffi (1.17.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    karafka-core (2.4.3)
-      karafka-rdkafka (>= 0.15.0, < 0.17.0)
-    karafka-rdkafka (0.16.0)
+    karafka-core (2.4.4)
+      karafka-rdkafka (>= 0.15.0, < 0.18.0)
+    karafka-rdkafka (0.17.6)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
@@ -48,9 +48,9 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.0)
+    rspec-core (3.13.1)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.1)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-mocks (3.13.1)
@@ -62,11 +62,11 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
+    simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.16)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   ruby
@@ -81,4 +81,4 @@ DEPENDENCIES
   waterdrop!
 
 BUNDLED WITH
-   2.5.14
+   2.5.16

--- a/waterdrop.gemspec
+++ b/waterdrop.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |spec|
   spec.licenses      = %w[LGPL-3.0-only Commercial]
 
   spec.add_dependency 'karafka-core', '>= 2.4.3', '< 3.0.0'
-  spec.add_dependency 'karafka-rdkafka', '>= 0.15.1'
+  spec.add_dependency 'karafka-rdkafka', '>= 0.17.5'
   spec.add_dependency 'zeitwerk', '~> 2.3'
 
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   if $PROGRAM_NAME.end_with?('gem')
     spec.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')


### PR DESCRIPTION
Per our EOL policy, Ruby 3.0 is soon going to go down. There is no point in releasing breaking release without this change.