### PR TITLE
stabilize spec

### DIFF
--- a/spec/lib/waterdrop/producer/transactions_spec.rb
+++ b/spec/lib/waterdrop/producer/transactions_spec.rb
@@ -291,6 +291,7 @@ RSpec.describe_current do
         end
 
         producer.transaction do
+          sleep(0.1)
           producer.produce_async(topic: 'example_topic', payload: 'na')
 
           raise(WaterDrop::AbortTransaction)


### PR DESCRIPTION
without this sleep it may be that the dispatch from waterdrop is not happening fast enough and no purge is needed