### PR TITLE
use karafka-rdkafka 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WaterDrop changelog
 
+## 2.8.4 (Unreleased)
+- [Change] Require `karafka-rdkafka` `>=` `0.20.0.rc1`.
+
 ## 2.8.3 (2025-04-08)
 - [Enhancement] Support producing messages with arrays of strings in headers (KIP-82).
 - [Refactor] Introduce a `bin/verify_topics_naming` script to ensure proper test topics naming convention.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     waterdrop (2.8.4)
       karafka-core (>= 2.4.9, < 3.0.0)
-      karafka-rdkafka (>= 0.20.0.rc1)
+      karafka-rdkafka (>= 0.20.0.rc2)
       zeitwerk (~> 2.3)
 
 GEM
@@ -26,8 +26,9 @@ GEM
     karafka-core (2.4.10)
       karafka-rdkafka (>= 0.17.6, < 0.20.0)
       logger (>= 1.6.0)
-    karafka-rdkafka (0.20.0.rc1)
+    karafka-rdkafka (0.20.0.rc2)
       ffi (~> 1.15)
+      logger (>= 1.5)
       mini_portile2 (~> 2.6)
       rake (> 12)
     logger (1.6.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.8.3)
+    waterdrop (2.8.4)
       karafka-core (>= 2.4.9, < 3.0.0)
-      karafka-rdkafka (>= 0.19.1)
+      karafka-rdkafka (>= 0.20.0.rc1)
       zeitwerk (~> 2.3)
 
 GEM
@@ -26,7 +26,7 @@ GEM
     karafka-core (2.4.10)
       karafka-rdkafka (>= 0.17.6, < 0.20.0)
       logger (>= 1.6.0)
-    karafka-rdkafka (0.19.1)
+    karafka-rdkafka (0.20.0.rc1)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = '2.8.3'
+  VERSION = '2.8.4'
 end

--- a/spec/lib/waterdrop/producer_spec.rb
+++ b/spec/lib/waterdrop/producer_spec.rb
@@ -130,7 +130,8 @@ RSpec.describe_current do
     context 'when topic does not exist' do
       let(:topic) { "it-#{SecureRandom.uuid}" }
 
-      it { expect { count }.to raise_error(Rdkafka::RdkafkaError, /unknown_topic_or_part/) }
+      # Older versions of librdkafka (pre 2.10) would raise error, after that it will not
+      it { expect(count).to eq(1) }
     end
 
     context 'when topic exists' do

--- a/waterdrop.gemspec
+++ b/waterdrop.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.licenses      = %w[LGPL-3.0-only Commercial]
 
   spec.add_dependency 'karafka-core', '>= 2.4.9', '< 3.0.0'
-  spec.add_dependency 'karafka-rdkafka', '>= 0.19.1'
+  spec.add_dependency 'karafka-rdkafka', '>= 0.20.0.rc1'
   spec.add_dependency 'zeitwerk', '~> 2.3'
 
   spec.required_ruby_version = '>= 3.1.0'

--- a/waterdrop.gemspec
+++ b/waterdrop.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.licenses      = %w[LGPL-3.0-only Commercial]
 
   spec.add_dependency 'karafka-core', '>= 2.4.9', '< 3.0.0'
-  spec.add_dependency 'karafka-rdkafka', '>= 0.20.0.rc1'
+  spec.add_dependency 'karafka-rdkafka', '>= 0.20.0.rc2'
   spec.add_dependency 'zeitwerk', '~> 2.3'
 
   spec.required_ruby_version = '>= 3.1.0'


### PR DESCRIPTION
This PR makes the master dependent on `0.20.0.rc1` so we can test things out and then align specs and expectations against new rdkafka.