### PR TITLE
A producer is not idempotent unless the enable.idempotence config is true

### DIFF
--- a/lib/waterdrop/producer.rb
+++ b/lib/waterdrop/producer.rb
@@ -169,7 +169,7 @@ module WaterDrop
       return true if transactional?
       return @idempotent if instance_variable_defined?(:'@idempotent')
 
-      @idempotent = config.kafka.to_h.key?(:'enable.idempotence')
+      @idempotent = config.kafka.to_h.fetch(:'enable.idempotence', false)
     end
 
     # Returns and caches the middleware object that may be used


### PR DESCRIPTION
It may be that a client has explicitly set `enable.idempotence` to false, so checking of the key is set may lead to false positives.

In practice this led to a `VariantInvalidError` because a variant was trying to override `required.acks` for a producer that had explicitly set `enable.idempotence` to false. 