### PR TITLE
disconnecting api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # WaterDrop changelog
 
 ## 2.8.6 (Unreleased)
+- [Enhancement] Introduce the `WaterDrop::Producer#disconnect` so users can write custom logic to save on connections then producer is only used from time to time.
 - [Enhancement] Introduce `WaterDrop::Producer#inspect` that is mutex-safe.
 - [Enhancement] Raise errors on detected Ruby warnings.
 - [Enhancement] Optimize producer for Ruby shapes.

--- a/lib/waterdrop/instrumentation/notifications.rb
+++ b/lib/waterdrop/instrumentation/notifications.rb
@@ -11,6 +11,7 @@ module WaterDrop
         producer.closing
         producer.closed
         producer.reloaded
+        producer.disconnected
 
         message.produced_async
         message.produced_sync

--- a/lib/waterdrop/producer/status.rb
+++ b/lib/waterdrop/producer/status.rb
@@ -9,6 +9,7 @@ module WaterDrop
         initial
         configured
         connected
+        disconnected
         closing
         closed
       ].freeze
@@ -22,11 +23,12 @@ module WaterDrop
       end
 
       # @return [Boolean] true if producer is in a active state. Active means, that we can start
-      #   sending messages. Actives states are connected (connection established) or configured,
-      #   which means, that producer is configured, but connection with Kafka is
-      #   not yet established.
+      #   sending messages. Active states are connected (connection established), configured
+      #   which means, that producer is configured, but connection with Kafka is not yet
+      #   established or disconnected, meaning it was working but user disconnected for his own
+      #   reasons though sending could reconnect and continue.
       def active?
-        connected? || configured?
+        connected? || configured? || disconnected?
       end
 
       # @return [String] current status as a string

--- a/spec/lib/waterdrop/producer/buffer_spec.rb
+++ b/spec/lib/waterdrop/producer/buffer_spec.rb
@@ -176,4 +176,12 @@ RSpec.describe WaterDrop::Producer::Buffer do
       it { expect { flushing }.to raise_error(WaterDrop::Errors::ProduceManyError) }
     end
   end
+
+  context 'when we have data in the buffer' do
+    before { producer.buffer(build(:valid_message)) }
+
+    it 'expect not to allow for a disconnect' do
+      expect(producer.disconnect).to be(false)
+    end
+  end
 end

--- a/spec/lib/waterdrop/producer/status_spec.rb
+++ b/spec/lib/waterdrop/producer/status_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe_current do
     it { expect(status.configured?).to be(false) }
     it { expect(status.active?).to be(false) }
     it { expect(status.connected?).to be(false) }
+    it { expect(status.disconnected?).to be(false) }
     it { expect(status.closing?).to be(false) }
     it { expect(status.closed?).to be(false) }
     it { expect(status.to_s).to eq('initial') }
@@ -24,6 +25,7 @@ RSpec.describe_current do
     it { expect(status.configured?).to be(true) }
     it { expect(status.active?).to be(true) }
     it { expect(status.connected?).to be(false) }
+    it { expect(status.disconnected?).to be(false) }
     it { expect(status.closing?).to be(false) }
     it { expect(status.closed?).to be(false) }
     it { expect(status.to_s).to eq('configured') }
@@ -36,9 +38,23 @@ RSpec.describe_current do
     it { expect(status.configured?).to be(false) }
     it { expect(status.active?).to be(true) }
     it { expect(status.connected?).to be(true) }
+    it { expect(status.disconnected?).to be(false) }
     it { expect(status.closing?).to be(false) }
     it { expect(status.closed?).to be(false) }
     it { expect(status.to_s).to eq('connected') }
+  end
+
+  context 'when in the disconnected state' do
+    before { status.disconnected! }
+
+    it { expect(status.initial?).to be(false) }
+    it { expect(status.configured?).to be(false) }
+    it { expect(status.active?).to be(true) }
+    it { expect(status.connected?).to be(false) }
+    it { expect(status.disconnected?).to be(true) }
+    it { expect(status.closing?).to be(false) }
+    it { expect(status.closed?).to be(false) }
+    it { expect(status.to_s).to eq('disconnected') }
   end
 
   context 'when in the closing state' do
@@ -48,6 +64,7 @@ RSpec.describe_current do
     it { expect(status.configured?).to be(false) }
     it { expect(status.active?).to be(false) }
     it { expect(status.connected?).to be(false) }
+    it { expect(status.disconnected?).to be(false) }
     it { expect(status.closing?).to be(true) }
     it { expect(status.closed?).to be(false) }
     it { expect(status.to_s).to eq('closing') }
@@ -60,6 +77,7 @@ RSpec.describe_current do
     it { expect(status.configured?).to be(false) }
     it { expect(status.active?).to be(false) }
     it { expect(status.connected?).to be(false) }
+    it { expect(status.disconnected?).to be(false) }
     it { expect(status.closing?).to be(false) }
     it { expect(status.closed?).to be(true) }
     it { expect(status.to_s).to eq('closed') }

--- a/spec/lib/waterdrop/producer/sync_spec.rb
+++ b/spec/lib/waterdrop/producer/sync_spec.rb
@@ -231,4 +231,15 @@ RSpec.describe_current do
       it { expect(delivery).to be_a(Rdkafka::Producer::DeliveryReport) }
     end
   end
+
+  context 'when producing and disconnected in a loop' do
+    let(:message) { build(:valid_message) }
+
+    it 'expect to always disconnect and reconnect and continue to produce' do
+      100.times do |i|
+        expect(producer.produce_sync(message).offset).to eq(i)
+        producer.disconnect
+      end
+    end
+  end
 end

--- a/spec/lib/waterdrop/producer/transactions_spec.rb
+++ b/spec/lib/waterdrop/producer/transactions_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe_current do
 
       expect(transaction_result).to eq(result)
     end
+
+    it 'expect not to allow to disconnect producer during transaction' do
+      producer.transaction do
+        expect(producer.disconnect).to be(false)
+      end
+    end
+
+    it 'expect to allow to disconnect producer after transaction' do
+      producer.transaction do
+        producer.produce_async(topic: topic_name, payload: '2')
+      end
+
+      expect(producer.disconnect).to be(true)
+    end
   end
 
   context 'when we dispatch in transaction to multiple topics with array headers' do


### PR DESCRIPTION
this PR adds a simple disconnecting API that can be used to temporarily shutdown the producer and reactivate it when needed for low intensity operations to preserve connections.
