### PR TITLE
Update yard-lint to fail on convention severity

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -17,7 +17,7 @@ AllValidators:
     - 'test/**/*'
 
   # Exit code behavior (error, warning, convention, never)
-  FailOnSeverity: error
+  FailOnSeverity: convention
 
   # Minimum documentation coverage percentage (0-100)
   # Fails if coverage is below this threshold


### PR DESCRIPTION
Lower the FailOnSeverity threshold from 'error' to 'convention' to catch more documentation issues during CI.