### PR TITLE
Add Producer#queue_size to expose rdkafka queue length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.8.16 (Unreleased)
 - [Feature] Add FD-based polling mode (`config.polling.mode = :fd`) as an alternative to the default thread-based polling. FD mode uses a single Ruby thread with IO.select for efficient multiplexing, providing 39-54% higher throughput, lower memory usage, and fewer threads compared to the default thread mode.
 - [Feature] Add `config.polling.fd.max_time` setting (default: 100ms) to control maximum polling time per producer per cycle. This enables per-producer priority differentiation.
+- [Feature] Add `Producer#queue_size` (alias: `#queue_length`) to return the count of messages pending in the librdkafka queue. This counts messages that have been dispatched to librdkafka but not yet transmitted to the Kafka broker.
 - [Enhancement] Add `poll_nb` and `poll_drain` methods to rdkafka Producer for efficient non-blocking polling without GVL release overhead.
 - [Enhancement] Add `poller.producer_registered` and `poller.producer_unregistered` instrumentation events for FD mode.
 - [Change] Update to use `max_wait_timeout_ms` parameter in rdkafka `AbstractHandle#wait` for consistency with librdkafka conventions.

--- a/lib/waterdrop/clients/dummy.rb
+++ b/lib/waterdrop/clients/dummy.rb
@@ -57,6 +57,15 @@ module WaterDrop
         Handle.new(topic.to_s, partition, @counters["#{topic}#{partition}"] += 1)
       end
 
+      # Returns 0 as dummy client doesn't queue any real messages
+      #
+      # @return [Integer] always 0
+      def queue_size
+        0
+      end
+
+      alias_method :queue_length, :queue_size
+
       # @param _args [Object] anything really, this dummy is suppose to support anything
       def respond_to_missing?(*_args)
         true

--- a/spec/lib/waterdrop/clients/dummy_spec.rb
+++ b/spec/lib/waterdrop/clients/dummy_spec.rb
@@ -106,6 +106,11 @@ RSpec.describe_current do
     it { expect(client.respond_to?(:test)).to be(true) }
   end
 
+  describe "#queue_size" do
+    it { expect(client.queue_size).to eq(0) }
+    it { expect(client.queue_length).to eq(0) }
+  end
+
   describe "#transaction" do
     let(:producer) do
       WaterDrop::Producer.new do |config|


### PR DESCRIPTION
## Summary

Add a new `Producer#queue_size` method (with `#queue_length` alias) that returns the count of messages pending in the librdkafka producer queue. This provides visibility into:

- Messages waiting to be sent to the broker
- Messages currently in-flight (being transmitted)
- Delivery reports waiting to be processed

Inspired by [confluent-kafka-python PR #2140](https://github.com/confluentinc/confluent-kafka-python/pull/2140) which added `__len__` to AIOProducer.

## Implementation

- **Rdkafka patch**: Adds a monkey-patch module (`WaterDrop::Patches::RdkafkaProducer`) that wraps the existing `rd_kafka_outq_len` FFI binding (already present in karafka-rdkafka)
- **Producer method**: Exposes `queue_size`/`queue_length` on `WaterDrop::Producer` with proper status checks
- **Thread-safe**: Uses existing mutex synchronization patterns
- **Returns 0 when not connected**: Semantically correct since no messages can be pending if not connected
- **Dummy client support**: Returns 0 for test compatibility

## Future

The monkey-patch in `lib/waterdrop/patches/rdkafka_producer.rb` can be extracted to karafka-rdkafka gem in the future. The patch is cleanly isolated for easy extraction.

## Example Usage

```ruby
# Check pending messages in rdkafka queue
producer.queue_size #=> 42

# Check total pending work (buffer + rdkafka queue)
internal_buffer = producer.messages.size
rdkafka_queue = producer.queue_size
total_pending = internal_buffer + rdkafka_queue
```

## Test Plan

- [x] Tests for `WaterDrop::Producer#queue_size` in various states (not configured, configured, connected, closed)
- [x] Tests for concurrent access safety
- [x] Tests for `WaterDrop::Clients::Dummy#queue_size`
- [x] Tests for the Rdkafka::Producer patch
- [x] All existing tests pass
- [x] Coditsu code quality checks pass