### PR TITLE
Add integration spec for idempotent producer variant acks restriction

### DIFF
--- a/spec/integrations/idempotent_variant_acks/Gemfile
+++ b/spec/integrations/idempotent_variant_acks/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'waterdrop', path: ENV.fetch('WATERDROP_GEM_DIR', nil)

--- a/spec/integrations/idempotent_variant_acks/Gemfile.lock
+++ b/spec/integrations/idempotent_variant_acks/Gemfile.lock
@@ -1,0 +1,104 @@
+PATH
+  remote: /home/mencio/Software/Karafka/waterdrop
+  specs:
+    waterdrop (2.8.15)
+      karafka-core (>= 2.4.9, < 3.0.0)
+      karafka-rdkafka (>= 0.23.1)
+      zeitwerk (~> 2.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86-linux-gnu)
+    ffi (1.17.3-x86-linux-musl)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
+    json (2.18.0)
+    karafka-core (2.5.8)
+      karafka-rdkafka (>= 0.20.0)
+      logger (>= 1.6.0)
+    karafka-rdkafka (0.23.1)
+      ffi (~> 1.17.1)
+      json (> 2.0)
+      logger
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+    karafka-rdkafka (0.23.1-aarch64-linux-gnu)
+      ffi (~> 1.17.1)
+      json (> 2.0)
+      logger
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+    karafka-rdkafka (0.23.1-arm64-darwin)
+      ffi (~> 1.17.1)
+      json (> 2.0)
+      logger
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+    karafka-rdkafka (0.23.1-x86_64-linux-gnu)
+      ffi (~> 1.17.1)
+      json (> 2.0)
+      logger
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+    karafka-rdkafka (0.23.1-x86_64-linux-musl)
+      ffi (~> 1.17.1)
+      json (> 2.0)
+      logger
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+    logger (1.7.0)
+    mini_portile2 (2.8.9)
+    rake (13.3.1)
+    zeitwerk (2.7.4)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  waterdrop!
+
+CHECKSUMS
+  ffi (1.17.3) sha256=0e9f39f7bb3934f77ad6feab49662be77e87eedcdeb2a3f5c0234c2938563d4c
+  ffi (1.17.3-aarch64-linux-gnu) sha256=28ad573df26560f0aedd8a90c3371279a0b2bd0b4e834b16a2baa10bd7a97068
+  ffi (1.17.3-aarch64-linux-musl) sha256=020b33b76775b1abacc3b7d86b287cef3251f66d747092deec592c7f5df764b2
+  ffi (1.17.3-arm-linux-gnu) sha256=5bd4cea83b68b5ec0037f99c57d5ce2dd5aa438f35decc5ef68a7d085c785668
+  ffi (1.17.3-arm-linux-musl) sha256=0d7626bb96265f9af78afa33e267d71cfef9d9a8eb8f5525344f8da6c7d76053
+  ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
+  ffi (1.17.3-x86-linux-gnu) sha256=868a88fcaf5186c3a46b7c7c2b2c34550e1e61a405670ab23f5b6c9971529089
+  ffi (1.17.3-x86-linux-musl) sha256=f0286aa6ef40605cf586e61406c446de34397b85dbb08cc99fdaddaef8343945
+  ffi (1.17.3-x86_64-darwin) sha256=1f211811eb5cfaa25998322cdd92ab104bfbd26d1c4c08471599c511f2c00bb5
+  ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
+  ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
+  json (2.18.0) sha256=b10506aee4183f5cf49e0efc48073d7b75843ce3782c68dbeb763351c08fd505
+  karafka-core (2.5.8) sha256=3b056abe55cede3f189a3b68c444012f9fb70ec49afd8689c99702ab72837041
+  karafka-rdkafka (0.23.1) sha256=b248150477f672d047de44da24c89cf71a0bf5bd475f12a6214cc5fddeb65297
+  karafka-rdkafka (0.23.1-aarch64-linux-gnu) sha256=ce73057b9dee87155fc49328749c222a8780a54ed571ed2c0417970a70cfea37
+  karafka-rdkafka (0.23.1-arm64-darwin) sha256=2629f77b9cef4e9bb5f6a6baf5d15fd2b3fc9578ba2c914309d7ef655afe9a00
+  karafka-rdkafka (0.23.1-x86_64-linux-gnu) sha256=1e70456f94b6c0decec2bfecf250322830bef4d67fafe44384751b44093da415
+  karafka-rdkafka (0.23.1-x86_64-linux-musl) sha256=ba060677f5036b53c0bb4245f1472bbec87518d81d6d6054ffa23eb8ac2a7357
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  waterdrop (2.8.15)
+  zeitwerk (2.7.4) sha256=2bef90f356bdafe9a6c2bd32bcd804f83a4f9b8bc27f3600fff051eb3edcec8b
+
+BUNDLED WITH
+  4.0.3

--- a/spec/integrations/idempotent_variant_acks/idempotent_variant_acks_zero_spec.rb
+++ b/spec/integrations/idempotent_variant_acks/idempotent_variant_acks_zero_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Integration test for WaterDrop idempotent producer variant acks restriction
+# Tests that an idempotent producer with default acks: all cannot create a variant with acks: 0.
+#
+# Idempotent producers require acks: all to guarantee exactly-once semantics.
+# Allowing a variant with acks: 0 would break idempotency guarantees and is not permitted.
+
+require 'waterdrop'
+require 'logger'
+require 'securerandom'
+
+BOOTSTRAP_SERVERS = ENV.fetch('BOOTSTRAP_SERVERS', '127.0.0.1:9092')
+
+# Create idempotent producer with acks: all (required for idempotence)
+producer = WaterDrop::Producer.new do |config|
+  config.kafka = {
+    'bootstrap.servers': BOOTSTRAP_SERVERS,
+    'enable.idempotence': true,
+    'request.required.acks': 'all'
+  }
+  config.max_wait_timeout = 30_000
+  config.logger = Logger.new($stdout, level: Logger::INFO)
+end
+
+# Track test results
+variant_created = false
+correct_error_raised = false
+error_message = nil
+
+begin
+  # Attempt to create a variant with acks: 0 (should not be allowed)
+  variant = producer.variant(topic_config: { acks: 0 })
+
+  # If we get here, variant was created (should not happen)
+  variant_created = true
+
+  # Try to produce with the variant to trigger validation if deferred
+  topic_name = "it-idem-variant-acks-#{SecureRandom.hex(6)}"
+  variant.produce_sync(topic: topic_name, payload: 'test')
+rescue WaterDrop::Errors::VariantInvalidError => e
+  # This is the expected error
+  correct_error_raised = true
+  error_message = e.message
+rescue StandardError => e
+  # Any other error is unexpected
+  error_message = "Unexpected error: #{e.class}: #{e.message}"
+end
+
+producer.close
+
+# Verify results:
+# 1. Variant should not have been created successfully
+# 2. VariantInvalidError should have been raised
+success = !variant_created && correct_error_raised
+
+if success
+  puts 'SUCCESS: Idempotent producer correctly rejected variant with acks: 0'
+else
+  puts "FAILURE: variant_created=#{variant_created}, correct_error_raised=#{correct_error_raised}"
+  puts "Error: #{error_message}" if error_message
+end
+
+exit(success ? 0 : 1)


### PR DESCRIPTION
## Summary
- Add integration test to verify that an idempotent producer with `acks: all` cannot create a variant with `acks: 0`
- Ensures idempotency guarantees are preserved by preventing acks downgrades via variants

## Test plan
- [x] Run integration spec: `WATERDROP_GEM_DIR=$PWD bundle exec ruby spec/integrations/idempotent_variant_acks/idempotent_variant_acks_zero_spec.rb`
- [ ] Verify CI passes