### PR TITLE
Add .ruby-version to Renovate includePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended"
   ],
   "includePaths": [
+    ".ruby-version",
     "Gemfile",
     "waterdrop.gemspec",
     "spec/integrations/**/Gemfile",


### PR DESCRIPTION
## Summary
- Adds `.ruby-version` to the Renovate `includePaths` configuration
- This enables Renovate to detect and update the Ruby version specified in `.ruby-version`

## Test plan
- Renovate will now include `.ruby-version` in its scans and propose PRs when new Ruby versions are available