### PR TITLE
Extract linting tools to separate Gemfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
   yard-lint:
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: Gemfile.lint
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,4 @@ group :test do
   gem 'rspec'
   gem 'simplecov'
   gem 'warning'
-  gem 'yard-lint'
 end

--- a/Gemfile.lint
+++ b/Gemfile.lint
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Documentation linting
+gem 'yard-lint'

--- a/Gemfile.lint.lock
+++ b/Gemfile.lint.lock
@@ -1,0 +1,23 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    yard (0.9.38)
+    yard-lint (1.4.0)
+      yard (~> 0.9)
+      zeitwerk (~> 2.6)
+    zeitwerk (2.7.4)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  yard-lint
+
+CHECKSUMS
+  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
+  yard-lint (1.4.0) sha256=7dd88fbb08fd77cb840bea899d58812817b36d92291b5693dd0eeb3af9f91f0f
+  zeitwerk (2.7.4) sha256=2bef90f356bdafe9a6c2bd32bcd804f83a4f9b8bc27f3600fff051eb3edcec8b
+
+BUNDLED WITH
+  4.0.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,10 +86,6 @@ GEM
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     warning (1.5.0)
-    yard (0.9.38)
-    yard-lint (1.4.0)
-      yard (~> 0.9)
-      zeitwerk (~> 2.6)
     zeitwerk (2.7.4)
 
 PLATFORMS
@@ -113,7 +109,6 @@ DEPENDENCIES
   simplecov
   warning
   waterdrop!
-  yard-lint
   zeitwerk (~> 2.7.0)
 
 BUNDLED WITH

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "includePaths": [
     ".ruby-version",
     "Gemfile",
+    "Gemfile.lint",
     "waterdrop.gemspec",
     "spec/integrations/**/Gemfile",
     ".github/workflows/**"


### PR DESCRIPTION
## Summary

- Move `yard-lint` to a separate `Gemfile.lint` to isolate non-execution/linting dependencies
- Update CI to use `BUNDLE_GEMFILE=Gemfile.lint` for the yard-lint job
- Add `Gemfile.lint` to Renovate's `includePaths` for automatic dependency updates

## Test plan

- [ ] Verify yard-lint CI job passes with the separate Gemfile
- [ ] Confirm Renovate detects and tracks `Gemfile.lint`