### PR TITLE
Enable lockFileMaintenance in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,5 +45,8 @@
   "minimumReleaseAge": "7 days",
   "labels": [
     "dependencies"
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
This ensures Renovate periodically updates lockfile-only dependencies (transitive deps and those without version pins) that would otherwise never get updated.