### PR TITLE
Fix Producer#close raising ThreadError when called from a signal trap…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WaterDrop changelog
 
+## 2.10.1 (2026-05-25)
+- [Fix] Prevent `Producer#close` from raising `ThreadError: can't be called from trap context` when invoked from a Ruby signal trap context (e.g. Puma's `after_stopped` DSL hook in single mode). `close` now detects this case and delegates to a background thread, joining it so the caller blocks until the producer is fully closed (#866).
+
 ## 2.10.0 (2026-05-07)
 - [Fix] Clean up native rdkafka client, global instrumentation callbacks, and poller registration when `init_transactions` fails during producer client construction. Previously, each failed attempt permanently leaked native threads, pipe file descriptors, and callback registry entries because the started `rd_kafka_t` handle was abandoned without being destroyed.
 - **[Breaking]** Skip emitting librdkafka statistics when nothing is subscribed to `statistics.emitted` at the time the underlying rdkafka client is constructed. When no listener is present at build time, `statistics.interval.ms` is forced to `0` regardless of user configuration and the statistics callback is not registered, saving substantial allocations in the hot path (no JSON parsing, no statistics hash materialization, no decoration work). To use statistics, subscribe a listener to `statistics.emitted` BEFORE the first producer use (before the underlying client is lazily initialized).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    waterdrop (2.10.0)
+    waterdrop (2.10.1)
       karafka-core (>= 2.5.12, < 3.0.0)
       karafka-rdkafka (>= 0.24.0)
       zeitwerk (~> 2.3)
@@ -85,7 +85,7 @@ CHECKSUMS
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   warning (1.6.0) sha256=a49cdfae19fb77d19afff2efbe45f8ab759e9cd25b4e4ce2c79dbaf46bdb6c9e
-  waterdrop (2.10.0)
+  waterdrop (2.10.1)
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 
 BUNDLED WITH

--- a/lib/waterdrop/producer.rb
+++ b/lib/waterdrop/producer.rb
@@ -423,6 +423,20 @@ module WaterDrop
           end
         end
       end
+    rescue ThreadError => e
+      # Ruby raises ThreadError with this specific message when Mutex#synchronize (or #lock) is
+      # called from a signal trap context. There is no public Ruby API to detect trap context
+      # proactively - Thread.current is the same object as the main thread, its status is "run",
+      # and caller_locations contains no "trap" frame. The only observable difference is that
+      # blocking mutex operations raise this error. We re-raise anything else (e.g.
+      # "deadlock; recursive locking") so those are not silently swallowed.
+      #
+      # Puma's `after_stopped` DSL hook in single mode is one example that fires in trap context.
+      # We escape by delegating to a background thread and joining so the caller blocks until the
+      # producer is fully closed.
+      raise unless e.message == "can't be called from trap context"
+
+      Thread.new { close(force: force) }.value
     end
 
     # Closes the producer with forced close after timeout, purging any outgoing data

--- a/lib/waterdrop/version.rb
+++ b/lib/waterdrop/version.rb
@@ -3,5 +3,5 @@
 # WaterDrop library
 module WaterDrop
   # Current WaterDrop version
-  VERSION = "2.10.0"
+  VERSION = "2.10.1"
 end

--- a/test/lib/waterdrop/producer_test.rb
+++ b/test/lib/waterdrop/producer_test.rb
@@ -378,6 +378,28 @@ describe_current do
         refute(@producer.disconnect)
       end
     end
+
+    context "when called from a signal trap context" do
+      before do
+        @producer = build(:producer)
+      end
+
+      it "expect to close without raising ThreadError" do
+        error = nil
+
+        trap("USR1") do
+          @producer.close
+        rescue => e
+          error = e
+        end
+
+        Process.kill("USR1", Process.pid)
+        sleep(0.1)
+
+        assert_nil(error, "Expected no error but got: #{error}")
+        assert_predicate(@producer.status, :closed?)
+      end
+    end
   end
 
   describe "#close!" do


### PR DESCRIPTION
… context

Puma's `after_stopped` DSL hook in single mode runs in a Ruby signal trap context. Ruby forbids Mutex#synchronize from trap contexts and raises:
  ThreadError: can't be called from trap context

Producer#close calls @transaction_mutex.synchronize, which hits this restriction.

The fix rescues ThreadError at the method level and re-runs close in a background thread, joining it so the caller blocks until the producer is fully closed. This mirrors the existing pattern used to escape the fd-poller thread deadlock.

Closes https://github.com/karafka/waterdrop/issues/866