### PR TITLE
Enable all opt-in Ruby warning categories in test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WaterDrop changelog
 
+## 2.10.2 (Unreleased)
+- [Enhancement] Replace explicit `Warning[:performance]` opt-in with a dynamic approach using `Warning.categories` (available since Ruby 3.4) to automatically enable all stable opt-in warning categories in the test suite, including `:strict_unused_block` introduced in Ruby 4.0.
+
 ## 2.10.1 (2026-05-25)
 - [Fix] Prevent `Producer#close` from raising `ThreadError: can't be called from trap context` when invoked from a Ruby signal trap context (e.g. Puma's `after_stopped` DSL hook in single mode). `close` now detects this case and delegates to a background thread, joining it so the caller blocks until the producer is fully closed (#866).
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
-Warning[:performance] = true if RUBY_VERSION >= "3.3"
 Warning[:deprecated] = true
+# Enable all opt-in warning categories. Warning.categories is available since Ruby 3.4;
+# on older Rubies this is a no-op. We skip :deprecated (handled above) and :experimental
+# (too unstable) so only stable opt-in categories like :performance are auto-enabled.
+if Warning.respond_to?(:categories)
+  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+end
 $VERBOSE = true
 
 require "warning"


### PR DESCRIPTION
Replace the hardcoded `Warning[:performance] = true if RUBY_VERSION >= "3.3"` with a dynamic approach using `Warning.categories` (Ruby 3.4+). This automatically enables all stable opt-in categories (excluding :deprecated, which is already set explicitly, and :experimental, which is too unstable).

On Ruby 4.0+, this additionally enables :strict_unused_block, catching a class of bugs not previously covered by the test suite.