### PR TITLE
Fix race condition in IdleDisconnectorListener tests on macOS

### DIFF
--- a/test/lib/waterdrop/instrumentation/callbacks/delivery_test.rb
+++ b/test/lib/waterdrop/instrumentation/callbacks/delivery_test.rb
@@ -88,6 +88,12 @@ describe_current do
     describe "when there is a message that was not successfully delivered async" do
       before do
         @changed = []
+        # A 250-char name exceeds Kafka's hard 249-char limit so the broker always rejects
+        # it via the delivery callback. Plain lowercase letters pass rdkafka's local topic
+        # validation, so the produce is always queued (never raises inline). Using special
+        # characters like "$%^&*" is unreliable because newer rdkafka versions reject them
+        # locally, swallowing the error silently and never generating a delivery callback.
+        @invalid_topic = "a" * 250
 
         @producer.monitor.subscribe("error.occurred") do |event|
           @changed << event
@@ -96,7 +102,7 @@ describe_current do
         100.times do
           # We force it to bypass the validations, so we trigger an error on delivery
           # otherwise we would be stopped by WaterDrop itself
-          @producer.send(:client).produce(topic: "$%^&*", payload: "1")
+          @producer.send(:client).produce(topic: @invalid_topic, payload: "1")
         rescue Rdkafka::RdkafkaError
           nil
         end
@@ -111,7 +117,7 @@ describe_current do
       it { assert_kind_of(Rdkafka::RdkafkaError, @event.payload[:error]) }
       it { assert_equal(-1, @event.payload[:partition]) }
       it { assert_equal(-1001, @event.payload[:offset]) }
-      it { assert_equal("$%^&*", @event.payload[:topic]) }
+      it { assert_equal(@invalid_topic, @event.payload[:topic]) }
     end
 
     describe "when there is a message that was not successfully delivered sync" do

--- a/test/lib/waterdrop/instrumentation/idle_disconnector_listener_test.rb
+++ b/test/lib/waterdrop/instrumentation/idle_disconnector_listener_test.rb
@@ -58,14 +58,14 @@ describe_current do
       describe "when producer can be disconnected" do
         it "expect to disconnect the producer" do
           @listener.on_statistics_emitted(@event)
-          sleep(0.2) # a bit of time because disconnect happens async
+          wait_for_events(@disconnected_events, count: 1)
 
           assert_equal(1, @disconnected_events.size)
         end
 
         it "expect to emit disconnect event with producer id" do
           @listener.on_statistics_emitted(@event)
-          sleep(0.2) # a bit of time because disconnect happens async
+          wait_for_events(@disconnected_events, count: 1)
 
           assert_equal(@producer.id, @disconnected_events.first[:producer_id])
         end
@@ -73,8 +73,7 @@ describe_current do
         it "expect not to disconnect again on subsequent calls with same txmsgs" do
           @listener.on_statistics_emitted(@event)
           @listener.on_statistics_emitted(@event)
-
-          sleep(0.2) # a bit of time because disconnect happens async
+          wait_for_events(@disconnected_events, count: 1)
 
           assert_equal(1, @disconnected_events.size)
         end
@@ -119,7 +118,7 @@ describe_current do
           @producer.stubs(:disconnectable?).returns(true)
           @producer.stubs(:disconnect).raises(@test_error)
           @listener.on_statistics_emitted(@event)
-          sleep(0.1) # Give thread time to complete and handle error
+          wait_for_events(@error_events, count: 1)
 
           assert_empty(@disconnected_events)
           refute_empty(@error_events)
@@ -133,7 +132,7 @@ describe_current do
           @producer.stubs(:disconnectable?).returns(true)
           @producer.stubs(:disconnect).raises(@test_error)
           @listener.on_statistics_emitted(@event)
-          sleep(0.1) # Give thread time to complete
+          wait_for_events(@error_events, count: 1)
           new_activity_time = @listener.instance_variable_get(:@last_activity_time)
 
           assert_operator(new_activity_time, :>, old_activity_time)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -108,6 +108,13 @@ class Minitest::Spec
     instance
   end
 
+  # Polls until the given events array has at least +count+ entries or the timeout expires.
+  # Use this instead of bare sleep() when waiting for async events (e.g. disconnect threads).
+  def wait_for_events(events, count: 1, timeout: 5)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    sleep(0.01) until events.size >= count || Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+  end
+
   # Clean up the Poller singleton after each test to prevent mock leakage
   # Reset the Poller singleton between tests to prevent state leakage
   def teardown


### PR DESCRIPTION
Replace sleep-based waiting with a polling helper that waits until async disconnect events actually arrive. On macOS with thread-based polling, @client.close can take longer than the previous 0.2s fixed sleep, leaving @disconnected_events empty and causing a NoMethodError on .first[].

Fixes flaky failure in tests-macos (thread): CI run 27178120117.

close https://github.com/karafka/waterdrop/issues/875