### PR TITLE
Align wrapped comment lines to the line length limit

### DIFF
--- a/lib/waterdrop/connection_pool.rb
+++ b/lib/waterdrop/connection_pool.rb
@@ -254,8 +254,7 @@ module WaterDrop
     # for API consistency across both individual producers and connection pools
     alias_method :close, :shutdown
 
-    # Reload all connections in the pool
-    # Useful for configuration changes or error recovery
+    # Reload all connections in the pool. Useful for configuration changes or error recovery
     def reload
       @pool.reload do |producer|
         producer.close! if producer&.status&.active?

--- a/lib/waterdrop/errors.rb
+++ b/lib/waterdrop/errors.rb
@@ -80,7 +80,6 @@ module WaterDrop
     end
   end
 
-  # Alias so we can have a nicer API to abort transactions
-  # This makes referencing easier
+  # Alias so we can have a nicer API to abort transactions. This makes referencing easier
   AbortTransaction = Errors::AbortTransaction
 end

--- a/lib/waterdrop/instrumentation/callbacks/error.rb
+++ b/lib/waterdrop/instrumentation/callbacks/error.rb
@@ -21,8 +21,7 @@ module WaterDrop
         # @note When there is a particular message produce error (not internal error), the error
         #   is shipped via the delivery callback, not via error callback.
         def call(client_name, error)
-          # Emit only errors related to our client
-          # Same as with statistics (mor explanation there)
+          # Emit only errors related to our client, same as with statistics (mor explanation there)
           return unless @client_name == client_name
 
           @monitor.instrument(

--- a/lib/waterdrop/instrumentation/vendors/datadog/metrics_listener.rb
+++ b/lib/waterdrop/instrumentation/vendors/datadog/metrics_listener.rb
@@ -218,8 +218,7 @@ module WaterDrop
             when :brokers
               statistics.fetch("brokers").each_value do |broker_statistics|
                 # Skip bootstrap nodes
-                # Bootstrap nodes have nodeid -1, other nodes have positive
-                # node ids
+                # Bootstrap nodes have nodeid -1, other nodes have positive node ids
                 next if broker_statistics["nodeid"] == -1
 
                 public_send(

--- a/lib/waterdrop/polling/config.rb
+++ b/lib/waterdrop/polling/config.rb
@@ -16,8 +16,7 @@ module WaterDrop
       extend ::Karafka::Core::Configurable
 
       # Ruby thread priority for the poller thread
-      # Valid range: -3 to 3 (Ruby's thread priority range)
-      # Higher values = higher priority
+      # Valid range: -3 to 3 (Ruby's thread priority range). Higher values = higher priority
       setting :thread_priority, default: 0
 
       # IO.select timeout in milliseconds

--- a/lib/waterdrop/polling/latch.rb
+++ b/lib/waterdrop/polling/latch.rb
@@ -33,8 +33,7 @@ module WaterDrop
         end
       end
 
-      # Waits until the latch is released
-      # Returns immediately if already released
+      # Waits until the latch is released. Returns immediately if already released
       def wait
         @mutex.synchronize do
           @cv.wait(@mutex) until @released

--- a/lib/waterdrop/polling/poller.rb
+++ b/lib/waterdrop/polling/poller.rb
@@ -186,8 +186,7 @@ module WaterDrop
         @ios_dirty = true
       end
 
-      # Ensures the polling thread is running
-      # Must be called within @mutex.synchronize
+      # Ensures the polling thread is running. Must be called within @mutex.synchronize
       def ensure_thread_running!
         return if @thread&.alive?
 

--- a/lib/waterdrop/polling/queue_pipe.rb
+++ b/lib/waterdrop/polling/queue_pipe.rb
@@ -25,8 +25,7 @@ module WaterDrop
         client.enable_queue_io_events(@writer.fileno)
       end
 
-      # Signals by writing a byte to the pipe
-      # Used to wake IO.select for continue/close signals
+      # Signals by writing a byte to the pipe. Used to wake IO.select for continue/close signals
       # Thread-safe and non-blocking; silently ignores errors
       def signal
         @writer.write_nonblock("W", exception: false)

--- a/lib/waterdrop/polling/state.rb
+++ b/lib/waterdrop/polling/state.rb
@@ -53,8 +53,7 @@ module WaterDrop
         @io = @queue_pipe.reader
       end
 
-      # Drains the queue pipe
-      # Called before polling to clear any pending signals
+      # Drains the queue pipe. Called before polling to clear any pending signals
       def drain
         @queue_pipe.drain
       end
@@ -88,8 +87,7 @@ module WaterDrop
 
       private_constant :STALE_CHECK_THROTTLE_MS
 
-      # Marks this producer as having been polled
-      # Called after polling to track staleness
+      # Marks this producer as having been polled. Called after polling to track staleness
       def mark_polled!
         @last_poll_time = monotonic_now
       end

--- a/lib/waterdrop/producer.rb
+++ b/lib/waterdrop/producer.rb
@@ -152,8 +152,7 @@ module WaterDrop
 
         # We should raise an error when trying to use a producer with client from a fork. Always.
         if @client
-          # We need to reset the client, otherwise there might be attempt to close the parent
-          # client
+          # We need to reset the client, otherwise there might be attempt to close the parent client
           @client = nil
           raise Errors::ProducerUsedInParentProcess, Process.pid
         end


### PR DESCRIPTION
Join prose comment lines that were split mid-sentence with no reason to stay under the line length limit. Skips license headers, YARD tags, code examples, feature-list bullets, and conceptually separate sentences.