### PR TITLE
Expose Producer#current_variant as a public method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # WaterDrop changelog
 
 ## 2.10.2 (Unreleased)
+- [Feature] Expose `Producer#current_variant` as a public method. It returns the variant active for the current dispatch on the current fiber - the custom variant while inside a `#with`/`#variant`-wrapped call, otherwise the producer's default variant - so middleware and instrumentation listeners running synchronously within a dispatch can read the effective per-dispatch settings (`topic_config`, `max_wait_timeout`, `default?`). The lookup is fiber-local and dispatch-scoped: outside a variant-wrapped call (or from an asynchronous delivery callback) it returns the default variant.
 - [Enhancement] Stop allocating one interpolated string per message in `LoggerListener` batch produce handlers. The quoted topic strings were only ever counted (quoting is a 1:1 mapping), never displayed, so counting the raw topic values yields the identical number with zero string allocations - relevant for large `produce_many_*` batches with the default logger listener attached.
 - [Enhancement] Use `Array#concat` in `Producer#buffer_many` instead of appending messages one by one.
 - [Enhancement] Skip building the `message.acknowledged` instrumentation payload in the delivery callback when nothing is subscribed to that event. The notifications bus already short-circuits on empty listeners, but only after the payload hash was allocated - once per delivered message on the polling thread. Mirrors the listener guard already used by the statistics callback. Late subscribers keep working as the check happens on each emission.

--- a/lib/waterdrop/producer.rb
+++ b/lib/waterdrop/producer.rb
@@ -263,6 +263,29 @@ module WaterDrop
       @middleware ||= config.middleware
     end
 
+    # Returns the variant currently in effect for dispatches on the current fiber.
+    #
+    # While executing inside a variant-wrapped call (any method invoked on the object returned by
+    # {#with} / {#variant}), this returns that variant; otherwise it returns the producer's default
+    # variant. It is primarily useful to middleware and instrumentation listeners that run
+    # synchronously within a dispatch and want to read the effective per-dispatch settings, such as
+    # `#topic_config`, `#max_wait_timeout` or `#default?`.
+    #
+    # @return [WaterDrop::Producer::Variant] the variant active for the current dispatch on this
+    #   fiber, or the producer's default variant when not inside a variant-wrapped call
+    #
+    # @note The lookup is fiber-local and scoped to a single dispatch; it does not represent a
+    #   producer-wide setting. Called from arbitrary code outside a variant-wrapped call it always
+    #   returns the default variant. It is likewise not meaningful from asynchronous delivery
+    #   callbacks (which run on the poller thread, a different fiber) - there it also returns the
+    #   default variant, not the variant the acknowledged message was dispatched with.
+    def current_variant
+      # Read-only: the fiber-local hash is created by the variant wrapper methods only when needed,
+      # so we must not allocate it here just to look up a variant that may not exist.
+      clients = Fiber.current.waterdrop_clients
+      (clients && clients[id]) || @default_variant
+    end
+
     # Disconnects the producer from Kafka while keeping it configured for potential reconnection
     #
     # This method safely disconnects the underlying Kafka client while preserving the producer's
@@ -559,15 +582,6 @@ module WaterDrop
         max_wait_timeout_ms: max_wait_timeout,
         raise_response_error: raise_response_error
       )
-    end
-
-    # @return [Producer::Variant] the variant config. Either custom if built using `#with` or
-    #   a default one.
-    # @note Read-only path. The fiber-local hash is created by the variant wrapper methods when
-    #   needed, so we must not allocate it here just to look up a variant that may not exist.
-    def current_variant
-      clients = Fiber.current.waterdrop_clients
-      (clients && clients[id]) || @default_variant
     end
 
     # Dispatches a message, ensuring transactional producers take the transaction lock before the

--- a/test/lib/waterdrop/producer_test.rb
+++ b/test/lib/waterdrop/producer_test.rb
@@ -286,6 +286,46 @@ describe_current do
     end
   end
 
+  describe "#current_variant" do
+    before do
+      @producer = build(:producer, deliver: false)
+    end
+
+    it "is a public method" do
+      assert_respond_to(@producer, :current_variant)
+    end
+
+    it "returns the default variant outside a variant-wrapped call" do
+      assert_predicate(@producer.current_variant, :default?)
+    end
+
+    it "returns the default variant during a plain (non-variant) dispatch" do
+      seen = nil
+      @producer.middleware.append(lambda do |message|
+        seen = @producer.current_variant
+        message
+      end)
+
+      @producer.produce_async(topic: @topic_name, payload: "data")
+
+      assert_predicate(seen, :default?)
+    end
+
+    it "returns the active variant while inside a variant-wrapped dispatch" do
+      variant = @producer.with(max_wait_timeout: 1_234)
+      seen = nil
+      @producer.middleware.append(lambda do |message|
+        seen = @producer.current_variant
+        message
+      end)
+
+      variant.produce_async(topic: @topic_name, payload: "data")
+
+      assert_same(variant, seen)
+      refute_predicate(seen, :default?)
+    end
+  end
+
   describe "#close" do
     context "when producer is already closed" do
       before do


### PR DESCRIPTION
Closes #897.

current_variant returns the variant active for the current dispatch on the current fiber - the custom variant while inside a #with / #variant-wrapped call, otherwise the producer's default variant. Moving it from private to public lets middleware and instrumentation listeners that run synchronously within a dispatch read the effective per-dispatch settings (topic_config, max_wait_timeout, default?).