### PR TITLE
Run librdkafka#4849 canary only on Linux

### DIFF
--- a/test/integrations/transactional_abort_race_canary/transactional_abort_race_canary_spec.rb
+++ b/test/integrations/transactional_abort_race_canary/transactional_abort_race_canary_spec.rb
@@ -28,6 +28,18 @@
 require "waterdrop"
 require "logger"
 require "securerandom"
+require "rbconfig"
+
+# librdkafka#4849 only reproduces reliably on Linux. On other platforms (notably macOS) the abort's
+# EndTxn does not race the coordinator registration the same way, so phase 1 can NEVER observe the
+# defect - and a canary whose whole job is "the bug must still reproduce" would then raise a false
+# "fixed upstream" retirement alarm, telling us to delete a mitigation that is still needed
+# everywhere. The window's absence here is a property of the platform, not evidence about the bug,
+# so we run this retirement alarm only where the defect actually lives.
+unless RbConfig::CONFIG["host_os"].match?(/linux/i)
+  puts "SKIP: librdkafka#4849 canary only runs on Linux (host_os=#{RbConfig::CONFIG["host_os"]})"
+  exit(0)
+end
 
 BOOTSTRAP_SERVERS = ENV.fetch("BOOTSTRAP_SERVERS", "127.0.0.1:9092")
 

--- a/test/lib/waterdrop/instrumentation/callbacks/delivery_test.rb
+++ b/test/lib/waterdrop/instrumentation/callbacks/delivery_test.rb
@@ -95,20 +95,37 @@ describe_current do
         # locally, swallowing the error silently and never generating a delivery callback.
         @invalid_topic = "a" * 250
 
-        @producer.monitor.subscribe("error.occurred") do |event|
+        # Bound how long librdkafka may hold the undeliverable message before it fails it and
+        # fires the delivery callback. With WaterDrop's 150s default `message.timeout.ms`, the
+        # only thing that fails the message inside the wait window is the broker's metadata
+        # rejection of the invalid topic - and that round-trip can occasionally exceed the
+        # deadline on a cold, loaded CI runner, leaving @changed empty and flaking the test. A
+        # short `message.timeout.ms` guarantees the error.occurred event fires within that bound
+        # regardless of metadata timing; on a healthy run the broker still rejects first, so we
+        # keep exercising the real rejection path and only fall back to the timeout when slow.
+        producer = build(
+          :producer,
+          kafka: {
+            "bootstrap.servers": BOOTSTRAP_SERVERS,
+            "message.timeout.ms": 5_000
+          }
+        )
+
+        producer.monitor.subscribe("error.occurred") do |event|
           @changed << event
         end
 
         100.times do
           # We force it to bypass the validations, so we trigger an error on delivery
           # otherwise we would be stopped by WaterDrop itself
-          @producer.send(:client).produce(topic: @invalid_topic, payload: "1")
+          producer.send(:client).produce(topic: @invalid_topic, payload: "1")
         rescue Rdkafka::RdkafkaError
           nil
         end
 
-        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 10
-        sleep(0.01) until @changed.size.positive? || Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        # Comfortably above `message.timeout.ms` so the guaranteed failure has landed; only the
+        # genuine "no event ever" case spends the full deadline before failing.
+        wait_for_events(@changed, count: 1, timeout: 20)
         @event = @changed.last
 
         refute_nil @event, "No error.occurred event received within deadline"


### PR DESCRIPTION
The transactional_abort_race_canary spec is a retirement alarm: phase 1 requires librdkafka#4849 to still reproduce, and treats a non-reproduction as evidence the defect was fixed upstream (a hard failure prompting removal of the mitigation).

That inference only holds on Linux. On macOS the abort's EndTxn does not race the coordinator registration the same way, so phase 1 can never observe the defect and the canary fails with a false 'fixed upstream' alarm - i.e. it fails precisely because librdkafka appears to work there. The window's absence is a property of the platform, not evidence about the bug.

Skip the canary (exit 0) on non-Linux hosts so it only runs where the defect actually lives. The sibling transactional_abort_after_commit_race spec is unaffected: it never requires the race to fire and stays green cross-platform.