### PR TITLE
Standardize yard-lint config: enable em-dash substitution as error

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -81,6 +81,14 @@ Documentation/LineLength:
   # Aligned with RuboCop's Layout/LineLength (Max: 100).
   MaxLength: 100
 
+Documentation/TextSubstitution:
+  Description: Detects em/en-dashes in documentation and replaces them with hyphens.
+  Enabled: true
+  Severity: error
+  Substitutions:
+    "—": "-"    # em-dash (U+2014)
+    "–": "-"    # en-dash (U+2013)
+
 # Tags validators
 Tags/Order:
   Description: Enforces consistent ordering of YARD tags.

--- a/lib/waterdrop/clients/rdkafka.rb
+++ b/lib/waterdrop/clients/rdkafka.rb
@@ -51,7 +51,7 @@ module WaterDrop
         # saves a significant number of allocations on the Ruby side (no JSON parsing, no
         # statistics hash materialization, no decorator work). Any listener subscribed after
         # the client has been built will not receive `statistics.emitted` events because
-        # librdkafka never emits them in the first place — to use statistics, subscribe a
+        # librdkafka never emits them in the first place - to use statistics, subscribe a
         # listener BEFORE the first producer use.
         #
         # When statistics end up disabled (either because the user explicitly set the interval
@@ -94,7 +94,7 @@ module WaterDrop
 
         # Registers the global callbacks (statistics, error, oauth refresh) for this producer
         # on the shared `Karafka::Core::Instrumentation` managers. The statistics callback is
-        # only registered when librdkafka is actually going to emit statistics — otherwise it
+        # only registered when librdkafka is actually going to emit statistics - otherwise it
         # would never fire and would only waste memory and a manager slot.
         #
         # @param producer [WaterDrop::Producer]

--- a/lib/waterdrop/instrumentation/monitor.rb
+++ b/lib/waterdrop/instrumentation/monitor.rb
@@ -28,8 +28,8 @@ module WaterDrop
       # Marks this monitor as no longer accepting new subscriptions to `statistics.emitted`.
       # Called by the rdkafka client builder when it decides to leave librdkafka statistics
       # disabled (because no listener was present at build time). Any subsequent attempt to
-      # subscribe to `statistics.emitted` — either via a block or via a listener object that
-      # responds to `on_statistics_emitted` — will raise
+      # subscribe to `statistics.emitted` - either via a block or via a listener object that
+      # responds to `on_statistics_emitted` - will raise
       # `WaterDrop::Errors::StatisticsNotEnabledError` instead of silently doing nothing.
       def freeze_statistics_listeners!
         @statistics_listeners_frozen = true

--- a/lib/waterdrop/producer/tombstone.rb
+++ b/lib/waterdrop/producer/tombstone.rb
@@ -16,7 +16,7 @@ module WaterDrop
       # Produces a tombstone message to Kafka and waits for it to be delivered
       #
       # @param message [Hash] hash with at least `:topic`, `:key`, and `:partition` keys.
-      #   `:payload` is not accepted — it will be silently removed if present.
+      #   `:payload` is not accepted - it will be silently removed if present.
       #
       # @return [Rdkafka::Producer::DeliveryReport] delivery report
       #
@@ -28,7 +28,7 @@ module WaterDrop
       # Produces a tombstone message to Kafka and does not wait for results
       #
       # @param message [Hash] hash with at least `:topic`, `:key`, and `:partition` keys.
-      #   `:payload` is not accepted — it will be silently removed if present.
+      #   `:payload` is not accepted - it will be silently removed if present.
       #
       # @return [Rdkafka::Producer::DeliveryHandle] delivery handle
       #


### PR DESCRIPTION
Enable Documentation/TextSubstitution (em/en-dash -> hyphen) as an error to match the ecosystem standard, and replace existing em/en-dashes in documentation.