### PR TITLE
Fix flaky #partition_count test with wait_until helper

### DIFF
--- a/test/lib/waterdrop/instrumentation/vendors/datadog/metrics_listener_test.rb
+++ b/test/lib/waterdrop/instrumentation/vendors/datadog/metrics_listener_test.rb
@@ -81,9 +81,7 @@ describe_current do
     before do
       @producer.produce_sync(topic: @topic, payload: rand.to_s)
 
-      # The assertions below check that values vary across emissions (uniq.size > 1), so we need
-      # several statistics snapshots, not just one. Wait until enough have accumulated instead of
-      # betting on a fixed sleep, which under-samples on a loaded runner. Interval is 100ms.
+      # The assertions below check that values vary across emissions, so wait for several snapshots
       wait_until(timeout: 10) { @dummy_client.buffer[:count]["waterdrop.calls"].size >= 5 }
 
       @counts = @dummy_client.buffer[:count]
@@ -197,8 +195,6 @@ describe_current do
   describe "when message is acknowledged" do
     before do
       @producer.produce_sync(topic: @topic, payload: rand.to_s)
-      # Wait for the async acknowledgement callback to record the metric instead of betting on a
-      # fixed sleep.
       wait_until { @dummy_client.buffer[:increment]["waterdrop.acknowledged"].any? }
     end
 
@@ -223,7 +219,6 @@ describe_current do
     end
 
     it "expect error count to increase" do
-      # Wait for the error callback, which depends on librdkafka timing.
       error_received = wait_until { @dummy_client.buffer[:count]["waterdrop.error_occurred"].any? }
 
       assert(error_received)
@@ -259,8 +254,6 @@ describe_current do
   describe "when trying to publish a topic level metric" do
     before do
       @producer.produce_sync(topic: @topic, payload: rand.to_s)
-      # Wait for the statistics callback to populate the gauge buffer instead of betting on a fixed
-      # sleep.
       wait_until { @dummy_client.buffer[:gauge].any? }
 
       @guages = @dummy_client.buffer[:gauge]

--- a/test/lib/waterdrop/instrumentation/vendors/datadog/metrics_listener_test.rb
+++ b/test/lib/waterdrop/instrumentation/vendors/datadog/metrics_listener_test.rb
@@ -81,8 +81,10 @@ describe_current do
     before do
       @producer.produce_sync(topic: @topic, payload: rand.to_s)
 
-      # Give it some time to emit the stats
-      sleep(1)
+      # The assertions below check that values vary across emissions (uniq.size > 1), so we need
+      # several statistics snapshots, not just one. Wait until enough have accumulated instead of
+      # betting on a fixed sleep, which under-samples on a loaded runner. Interval is 100ms.
+      wait_until(timeout: 10) { @dummy_client.buffer[:count]["waterdrop.calls"].size >= 5 }
 
       @counts = @dummy_client.buffer[:count]
       @histograms = @dummy_client.buffer[:histogram]
@@ -195,8 +197,9 @@ describe_current do
   describe "when message is acknowledged" do
     before do
       @producer.produce_sync(topic: @topic, payload: rand.to_s)
-      # We need to give the async callback a bit of time to kick in
-      sleep(0.1)
+      # Wait for the async acknowledgement callback to record the metric instead of betting on a
+      # fixed sleep.
+      wait_until { @dummy_client.buffer[:increment]["waterdrop.acknowledged"].any? }
     end
 
     it "expect to have a proper metric in place" do
@@ -220,15 +223,8 @@ describe_current do
     end
 
     it "expect error count to increase" do
-      # Wait for error callback with retries since it depends on librdkafka timing
-      error_received = false
-      20.times do
-        if @dummy_client.buffer[:count]["waterdrop.error_occurred"].any?
-          error_received = true
-          break
-        end
-        sleep(0.25)
-      end
+      # Wait for the error callback, which depends on librdkafka timing.
+      error_received = wait_until { @dummy_client.buffer[:count]["waterdrop.error_occurred"].any? }
 
       assert(error_received)
     end
@@ -263,7 +259,9 @@ describe_current do
   describe "when trying to publish a topic level metric" do
     before do
       @producer.produce_sync(topic: @topic, payload: rand.to_s)
-      sleep(1)
+      # Wait for the statistics callback to populate the gauge buffer instead of betting on a fixed
+      # sleep.
+      wait_until { @dummy_client.buffer[:gauge].any? }
 
       @guages = @dummy_client.buffer[:gauge]
       @metric = described_class::RdKafkaMetric.new(:gauge, :topics, "topics.batchcnt.avg", %w[batchcnt avg])

--- a/test/lib/waterdrop/producer_test.rb
+++ b/test/lib/waterdrop/producer_test.rb
@@ -168,9 +168,6 @@ describe_current do
       end
 
       it do
-        # The first call kicks off an async metadata fetch and (with auto topic creation) the
-        # broker creating the topic. Poll until the partition count settles instead of betting on
-        # a fixed sleep, which races on slower/loaded runners and returns -1 (metadata not ready).
         count = wait_until { (partitions = @producer.partition_count(@topic)).positive? && partitions }
 
         assert_equal(1, count)
@@ -436,8 +433,6 @@ describe_current do
         end
 
         Process.kill("USR1", Process.pid)
-        # The USR1 handler closes the producer on the signal-handling thread, so it lands
-        # asynchronously. Wait for it to settle instead of betting on a fixed sleep.
         wait_until { @producer.status.closed? || error }
 
         assert_nil(error, "Expected no error but got: #{error}")
@@ -940,8 +935,6 @@ describe_current do
         sleep(1)
       end
 
-      # Wait for the idle-disconnect instrumentation to disconnect the short-idle producer instead
-      # of betting on a fixed sleep.
       wait_until { @used_short.status.disconnected? }
 
       refute_predicate(@never_used.status, :disconnected?)

--- a/test/lib/waterdrop/producer_test.rb
+++ b/test/lib/waterdrop/producer_test.rb
@@ -436,7 +436,9 @@ describe_current do
         end
 
         Process.kill("USR1", Process.pid)
-        sleep(0.1)
+        # The USR1 handler closes the producer on the signal-handling thread, so it lands
+        # asynchronously. Wait for it to settle instead of betting on a fixed sleep.
+        wait_until { @producer.status.closed? || error }
 
         assert_nil(error, "Expected no error but got: #{error}")
         assert_predicate(@producer.status, :closed?)
@@ -938,8 +940,9 @@ describe_current do
         sleep(1)
       end
 
-      # Give a bit of time for the instrumentation to kick in
-      sleep(1)
+      # Wait for the idle-disconnect instrumentation to disconnect the short-idle producer instead
+      # of betting on a fixed sleep.
+      wait_until { @used_short.status.disconnected? }
 
       refute_predicate(@never_used.status, :disconnected?)
       refute_predicate(@used.status, :disconnected?)

--- a/test/lib/waterdrop/producer_test.rb
+++ b/test/lib/waterdrop/producer_test.rb
@@ -168,10 +168,12 @@ describe_current do
       end
 
       it do
-        @producer.partition_count(@topic)
-        sleep(1)
+        # The first call kicks off an async metadata fetch and (with auto topic creation) the
+        # broker creating the topic. Poll until the partition count settles instead of betting on
+        # a fixed sleep, which races on slower/loaded runners and returns -1 (metadata not ready).
+        count = wait_until { (partitions = @producer.partition_count(@topic)).positive? && partitions }
 
-        assert_equal(1, @producer.partition_count(@topic))
+        assert_equal(1, count)
       rescue Rdkafka::RdkafkaError => e
         assert_kind_of(Rdkafka::RdkafkaError, e)
         assert_equal(:unknown_topic_or_part, e.code)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -117,6 +117,26 @@ class Minitest::Spec
     sleep(0.01) until events.size >= count || Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
   end
 
+  # Polls the given block until it returns a truthy value or the timeout expires, then returns
+  # the last value yielded by the block. Use this instead of a bare sleep() when waiting for an
+  # async condition to settle (e.g. Kafka metadata to propagate) so tests wake up as soon as the
+  # condition holds rather than always paying a fixed delay.
+  # @param timeout [Numeric] maximum number of seconds to wait
+  # @param interval [Numeric] delay in seconds between successive checks
+  # @yield block evaluated on each poll; its return value is inspected for truthiness
+  # @return [Object] the last value returned by the block
+  def wait_until(timeout: 5, interval: 0.1)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+
+    loop do
+      value = yield
+      return value if value
+      return value if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+      sleep(interval)
+    end
+  end
+
   # Clean up the Poller singleton after each test to prevent mock leakage
   # Reset the Poller singleton between tests to prevent state leakage
   def teardown


### PR DESCRIPTION
The '#partition_count when topic does not exist' test relied on a fixed sleep(1) between triggering the async metadata fetch (which auto-creates the topic) and asserting the partition count. On slower/loaded CI runners the metadata was not always ready within one second, so partition_count returned -1 and the test failed intermittently across the matrix.

Add a reusable wait_until helper in test_helper.rb that polls a block until it returns truthy or a timeout expires, and use it to wait for the partition count to settle. This removes the race and also returns as soon as the metadata is available instead of always paying a fixed delay.